### PR TITLE
Revert "Attempt to fix docs CI"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,35 +1,27 @@
-name: build and deploy mkdocs to github pages
+name: Build Docs
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
-    branches:
-      - master
+    branches: [master]
 
 jobs:
-  deploy:
+  build:
+    name: Build and Deploy Documentation
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Master
+        uses: actions/checkout@v2
+        
+      - name: Install setuptools
+        run: apt-get install python3-setuptools
+        
+      - name: Install Material
+        run: python3 -m pip install mkdocs-material
 
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
-          architecture: 'x64'
-
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip     # install pip
-          python3 -m pip install mkdocs            # install mkdocs 
-          python3 -m pip install mkdocs-material   # install material theme
-
-      - name: Build site
-        run: mkdocs build
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/public
+      - name: Build and Deploy Documentation using MkDocs
+        uses: Tangerine-Community/tangy-mkdocs-build-action@v1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,15 +55,15 @@ extra:
     # - type: 'linkedin'
     #   link: 'https://linkedin.com/in/squidfunk'
 
-# theme:
-#   name: 'material'
-#   palette:
-#     primary: 'green'
-#     accent: 'green'
-#   logo:
-#     icon: 'cloud'
-#   feature:
-#     tabs: false
+theme:
+  name: 'material'
+  palette:
+    primary: 'green'
+    accent: 'green'
+  logo:
+    icon: 'cloud'
+  feature:
+    tabs: false
 
 extra_css:
   - css/faq.css


### PR DESCRIPTION
Reverts SAP/project-kb#34
The PR did pass the CI steps, but wiped clean the gh-pages branch, resulting in an empty website
at https://sap.github.io/project-kb/