### PR TITLE
Fix creation of unknown files with steady.sh

### DIFF
--- a/kaybee/internal/tasks/data/default_config.yaml
+++ b/kaybee/internal/tasks/data/default_config.yaml
@@ -133,8 +133,15 @@ export:
           [ -d $vulnerability_id/$commit_id/before/$(dirname $F) ] || mkdir -p $vulnerability_id/$commit_id/before/$(dirname $F)
           [ -d $vulnerability_id/$commit_id/after/$(dirname $F) ] || mkdir -p $vulnerability_id/$commit_id/after/$(dirname $F)
 
-          git -C $repo_dir show $commit_id~1:$F > $vulnerability_id/$commit_id/before/$F
-          git -C $repo_dir show $commit_id:$F > $vulnerability_id/$commit_id/after/$F
+          if ( git -C $repo_dir cat-file -e $commit_id~1:$F &> /dev/null )
+          then
+            git -C $repo_dir show $commit_id~1:$F > $vulnerability_id/$commit_id/before/$F
+          fi
+
+          if ( git -C $repo_dir cat-file -e $commit_id:$F &> /dev/null )
+          then
+            git -C $repo_dir show $commit_id:$F > $vulnerability_id/$commit_id/after/$F
+          fi
         done
       }
 


### PR DESCRIPTION
This PR has 2 fixes -
1. Ignore error - `fatal: Path 'hawtio-system/src/test/resources/data/setenv.zip' does not exist in '8cf6848f4d4d4917a4551c9aa49dc00f699eb569~1'`
2. git -C $repo_dir show $commit_id~1:$F > $vulnerability_id/$commit_id/before/$F used to create files with no content. This PR fixes it.