### PR TITLE
Add contains jira reference feature

### DIFF
--- a/prospector/commit_processor/feature_extractor.py
+++ b/prospector/commit_processor/feature_extractor.py
@@ -16,12 +16,14 @@ def extract_features(commit: Commit, advisory_record: AdvisoryRecord) -> CommitF
         advisory_record.paths, commit.changed_files
     )
     n_changed_files = extract_n_changed_files(commit.changed_files)
+    contains_jira_reference = extract_contains_jira_reference(commit.jira_refs)
     commit_feature = CommitFeatures(
         commit=commit,
         references_vuln_id=references_vuln_id,
         time_between_commit_and_advisory_record=time_between_commit_and_advisory_record,
         changes_relevant_path=changes_relevant_path,
         n_changed_files=n_changed_files,
+        contains_jira_reference=contains_jira_reference,
     )
     return commit_feature
 
@@ -48,3 +50,7 @@ def extract_changes_relevant_path(
 
 def extract_n_changed_files(changed_files: "list[str]") -> int:
     return len(changed_files)
+
+
+def extract_contains_jira_reference(jira_references: "list[str]") -> bool:
+    return len(jira_references) > 0

--- a/prospector/commit_processor/test_feature_extractor.py
+++ b/prospector/commit_processor/test_feature_extractor.py
@@ -6,6 +6,7 @@ from git.git import Git
 
 from .feature_extractor import (
     extract_changes_relevant_path,
+    extract_contains_jira_reference,
     extract_features,
     extract_n_changed_files,
     extract_references_vuln_id,
@@ -40,6 +41,7 @@ def test_extract_features(repository):
     assert extracted_features.time_between_commit_and_advisory_record == 1000000
     assert extracted_features.changes_relevant_path
     assert extracted_features.n_changed_files == 1
+    assert extracted_features.contains_jira_reference
 
 
 def test_extract_references_vuln_id():
@@ -78,3 +80,8 @@ def test_extract_changes_relevant_path():
 
 def test_extract_n_changed_files():
     assert extract_n_changed_files(["a.java", "b.py", "c.php"]) == 3
+
+
+def test_extract_contains_jira_reference():
+    assert extract_contains_jira_reference(["NAME-213"])
+    assert not extract_contains_jira_reference([])

--- a/prospector/datamodel/commit_features.py
+++ b/prospector/datamodel/commit_features.py
@@ -9,3 +9,4 @@ class CommitFeatures(BaseModel):
     time_between_commit_and_advisory_record: int = 0
     changes_relevant_path: bool = False
     n_changed_files: int = 0
+    contains_jira_reference: bool = False

--- a/prospector/datamodel/commit_features_test.py
+++ b/prospector/datamodel/commit_features_test.py
@@ -14,6 +14,7 @@ def test_simple():
         time_between_commit_and_advisory_record=42,
         changes_relevant_path=True,
         n_changed_files=44,
+        contains_jira_reference=True,
     )
 
     assert commit_features.commit.repository == "https://github.com/abc/xyz"
@@ -21,3 +22,4 @@ def test_simple():
     assert commit_features.time_between_commit_and_advisory_record == 42
     assert commit_features.changes_relevant_path
     assert commit_features.n_changed_files == 44
+    assert commit_features.contains_jira_reference


### PR DESCRIPTION
A very simple feature that checks if commit references a Jira project or not. Despite its simplicity, we believe it should be made explicit in the CommitFeatures class for the sake of consistency.