### PR TITLE
Add n hunks feature

### DIFF
--- a/prospector/commit_processor/feature_extractor.py
+++ b/prospector/commit_processor/feature_extractor.py
@@ -15,11 +15,13 @@ def extract_features(commit: Commit, advisory_record: AdvisoryRecord) -> CommitF
     changes_relevant_path = extract_changes_relevant_path(
         advisory_record.paths, commit.changed_files
     )
+    n_hunks = extract_n_hunks(commit.hunk_count)
     commit_feature = CommitFeatures(
         commit=commit,
         references_vuln_id=references_vuln_id,
         time_between_commit_and_advisory_record=time_between_commit_and_advisory_record,
         changes_relevant_path=changes_relevant_path,
+        n_hunks=n_hunks,
     )
     return commit_feature
 
@@ -42,3 +44,7 @@ def extract_changes_relevant_path(
     of relevant paths (mentioned in the advisory record)
     """
     return any([changed_path in relevant_paths for changed_path in changed_paths])
+
+
+def extract_n_hunks(hunk_count: int) -> int:
+    return hunk_count

--- a/prospector/commit_processor/test_feature_extractor.py
+++ b/prospector/commit_processor/test_feature_extractor.py
@@ -7,6 +7,7 @@ from git.git import Git
 from .feature_extractor import (
     extract_changes_relevant_path,
     extract_features,
+    extract_n_hunks,
     extract_references_vuln_id,
     extract_time_between_commit_and_advisory_record,
 )
@@ -38,6 +39,7 @@ def test_extract_features(repository):
     assert extracted_features.references_vuln_id
     assert extracted_features.time_between_commit_and_advisory_record == 1000000
     assert extracted_features.changes_relevant_path
+    assert extracted_features.n_hunks == 1
 
 
 def test_extract_references_vuln_id():
@@ -72,3 +74,7 @@ def test_extract_changes_relevant_path():
     assert not extract_changes_relevant_path(
         relevant_paths=[path_1, path_2], changed_paths=[]
     )
+
+
+def test_extract_n_hunks():
+    assert extract_n_hunks(12) == 12

--- a/prospector/datamodel/commit_features.py
+++ b/prospector/datamodel/commit_features.py
@@ -8,3 +8,4 @@ class CommitFeatures(BaseModel):
     references_vuln_id: bool = False
     time_between_commit_and_advisory_record: int = 0
     changes_relevant_path: bool = False
+    n_hunks: int = 0

--- a/prospector/datamodel/commit_features_test.py
+++ b/prospector/datamodel/commit_features_test.py
@@ -13,9 +13,11 @@ def test_simple():
         references_vuln_id=True,
         time_between_commit_and_advisory_record=42,
         changes_relevant_path=True,
+        n_hunks=12,
     )
 
     assert commit_features.commit.repository == "https://github.com/abc/xyz"
     assert commit_features.references_vuln_id
     assert commit_features.time_between_commit_and_advisory_record == 42
     assert commit_features.changes_relevant_path
+    assert commit_features.n_hunks == 12


### PR DESCRIPTION
It is a simple copy of number of hunks from datamodel.Commit to CommitFeatures. However, since CommitFeatures represent the extracted features, this value should be one of them, thus we make it explicit.