### PR TITLE
Add GET for preprocessed commits to API

### DIFF
--- a/prospector/api/api_test.py
+++ b/prospector/api/api_test.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -24,3 +26,13 @@ def test_post_preprocessed_commits():
     commits = [commit_1, commit_2]
     response = client.post("/commits/", json=commits)
     assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_get_commits():
+    repository = "xxx"
+    commit_id = "yyy"
+    response = client.get("/commits/" + repository)
+    print(response.json())
+    assert response.status_code == 200
+    assert json.loads(response.json())[0]["id"] == commit_id

--- a/prospector/api/api_test.py
+++ b/prospector/api/api_test.py
@@ -22,17 +22,32 @@ def test_status():
 
 def test_post_preprocessed_commits():
     commit_1 = Commit(repository="xxx", commit_id="yyy").__dict__
-    commit_2 = Commit(repository="aaa", commit_id="bbb").__dict__
-    commits = [commit_1, commit_2]
+    commit_2 = Commit(repository="xxx", commit_id="zzz").__dict__
+    commit_3 = Commit(repository="aaa", commit_id="bbb").__dict__
+    commits = [commit_1, commit_2, commit_3]
     response = client.post("/commits/", json=commits)
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
 
-def test_get_commits():
+def test_get_specific_commit():
     repository = "xxx"
     commit_id = "yyy"
-    response = client.get("/commits/" + repository)
-    print(response.json())
+    response = client.get("/commits/" + repository + "?commit_id=" + commit_id)
     assert response.status_code == 200
     assert json.loads(response.json())[0]["id"] == commit_id
+
+
+def test_get_commits_by_repository_in_detail():
+    repository = "xxx"
+    response = client.get("/commits/" + repository + "?details=true")
+    assert response.status_code == 200
+    assert json.loads(response.json())[0]["id"] == "yyy"
+    assert json.loads(response.json())[1]["id"] == "zzz"
+
+
+def test_get_commits_by_repository():
+    repository = "xxx"
+    response = client.get("/commits/" + repository)
+    assert response.status_code == 200
+    assert response.json() == '[{"id": "yyy"}, {"id": "zzz"}]'

--- a/prospector/api/main.py
+++ b/prospector/api/main.py
@@ -95,8 +95,8 @@ async def create_data(repository_url, commit_id, label, vulnerability_id):
 @app.get("/commits/{repository_url}")
 # async def get_commits(repository_url, commit_id=None, token=Depends(oauth2_scheme)):
 async def get_commits(repository_url, commit_id=None):
-    commit = Commit(commit_id, repository_url)
-    data = db.lookup(commit)
+    commit = Commit(commit_id=commit_id, repository=repository_url)
+    data = db.lookup_json(commit)
 
     return data
 

--- a/prospector/api/main.py
+++ b/prospector/api/main.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI
@@ -94,9 +95,16 @@ async def create_data(repository_url, commit_id, label, vulnerability_id):
 # -----------------------------------------------------------------------------
 @app.get("/commits/{repository_url}")
 # async def get_commits(repository_url, commit_id=None, token=Depends(oauth2_scheme)):
-async def get_commits(repository_url, commit_id=None):
+async def get_commits(
+    repository_url: str,
+    commit_id: Optional[str] = None,
+    details: Optional[bool] = False,
+):
     commit = Commit(commit_id=commit_id, repository=repository_url)
-    data = db.lookup_json(commit)
+    # use case: if a particular commit is queried, details should be returned
+    if commit_id:
+        details = True
+    data = db.lookup_json(commit, details)
 
     return data
 

--- a/prospector/api/routers/preprocessed.py
+++ b/prospector/api/routers/preprocessed.py
@@ -36,4 +36,4 @@ async def upload_preprocessed_commit(payload: List[Commit]):
     for commit in payload:
         db.save(commit)
 
-    return payload
+    return {"status": "ok"}

--- a/prospector/datamodel/commit.py
+++ b/prospector/datamodel/commit.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, Field
@@ -5,7 +6,7 @@ from pydantic import BaseModel, Field
 
 class Commit(BaseModel):
     # class Commit:
-    commit_id: str
+    commit_id: Optional[str] = ""
     repository: str
     timestamp: Optional[int] = 0
     hunks: List[Tuple[int, int]] = Field(default_factory=list)
@@ -18,6 +19,32 @@ class Commit(BaseModel):
     ghissue_refs: List[str] = Field(default_factory=list)
     cve_refs: List[str] = Field(default_factory=list)
     tags: List[str] = Field(default_factory=list)
+
+
+def create_commit_object(commit_list):
+    # Converts raw data of lookup() to a Commit object
+    for i in (3, 6, 7, 8, 9, 10, 11, 12):
+        if commit_list[i] == "{}":
+            commit_list[i] = []
+        else:
+            commit_list[i] = json.dumps(commit_list[i])
+
+    commit_obj = Commit(
+        commit_id=commit_list[0],
+        repository=commit_list[1],
+        timestamp=commit_list[2],
+        hunks=commit_list[3],
+        hunk_count=commit_list[4],
+        message=commit_list[5],
+        diff=commit_list[6],
+        changed_files=commit_list[7],
+        message_reference_content=commit_list[8],
+        jira_refs=commit_list[9],
+        ghissue_refs=commit_list[10],
+        cve_refs=commit_list[11],
+        tags=commit_list[12],
+    )
+    return commit_obj
 
     # def format(self):
     #     out = "Commit: {} {}".format(self.repository.get_url(), self.commit_id)


### PR DESCRIPTION
Issue #118
This commit adds a GET request to serve preprocessed commits stored in the database for a given repository.
Also adds easier interfacing with DB via getting json output and converting raw output to Commit object.