### PR TITLE
Fix invalid yaml for statement of  CVE-2020-13954

### DIFF
--- a/statements/CVE-2020-13954/statement.yaml
+++ b/statements/CVE-2020-13954/statement.yaml
@@ -1,5 +1,5 @@
 vulnerability_id: CVE-2020-13954
-- links:
+links:
   - https://cxf.apache.org/security-advisories.data/CVE-2020-13954.txt.asc
 fixes:
 - id: 3.3.x


### PR DESCRIPTION
The yaml at https://github.com/SAP/project-kb/blob/vulnerability-data/statements/CVE-2020-13954/statement.yaml is invalid and unparsabel due to minor mistake. 