### PR TITLE
Use preprocessed commits from backend (concept)

### DIFF
--- a/prospector/client/cli/main.py
+++ b/prospector/client/cli/main.py
@@ -19,7 +19,7 @@ from client.cli.prospector_client import (
 )
 from git.git import GIT_CACHE
 
-DEFAULT_BACKEND = "http://localhost:8080"
+DEFAULT_BACKEND = "http://localhost:8000"
 
 logger = logging.getLogger("prospector")
 

--- a/prospector/client/cli/prospector_client.py
+++ b/prospector/client/cli/prospector_client.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from datetime import datetime
 from pprint import pprint
@@ -8,7 +9,7 @@ from tqdm import tqdm
 from commit_processor.feature_extractor import extract_features
 from commit_processor.preprocessor import preprocess_commit
 from datamodel.advisory import AdvisoryRecord
-from datamodel.commit import Commit, create_commit_object
+from datamodel.commit import Commit
 from filter_rank.rank import rank
 from filter_rank.rules import apply_rules
 from git.git import GIT_CACHE, Git
@@ -149,7 +150,8 @@ def prospector(  # noqa: C901
             backend_address
             + "/commits/"
             + repository_url
-            + candidates
+            + "?commit_id="
+            + ",".join(candidates)
             + "?details=true"
         )
         print("The backend returned status '%d'" % r.status_code)
@@ -161,11 +163,11 @@ def prospector(  # noqa: C901
 
     preprocessed_commits: "list[Commit]" = []
     missing = []
-    for idx, commit in enumerate(r.text):
+    for idx, commit in enumerate(json.loads(r.text)):
         if (
             commit
-        ):  # None results are not in the DB, collect them to missing list, they need local preporcessing
-            preprocessed_commits.append(create_commit_object(commit))
+        ):  # None results are not in the DB, collect them to missing list, they need local preprocessing
+            preprocessed_commits.append(Commit(commit))
         else:
             missing.append(candidates[idx])
 

--- a/prospector/datamodel/commit.py
+++ b/prospector/datamodel/commit.py
@@ -1,4 +1,3 @@
-import json
 from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, Field
@@ -19,32 +18,6 @@ class Commit(BaseModel):
     ghissue_refs: List[str] = Field(default_factory=list)
     cve_refs: List[str] = Field(default_factory=list)
     tags: List[str] = Field(default_factory=list)
-
-
-def create_commit_object(commit_list):
-    # Converts raw data of lookup() to a Commit object
-    for i in (3, 6, 7, 8, 9, 10, 11, 12):
-        if commit_list[i] == "{}":
-            commit_list[i] = []
-        else:
-            commit_list[i] = json.dumps(commit_list[i])
-
-    commit_obj = Commit(
-        commit_id=commit_list[0],
-        repository=commit_list[1],
-        timestamp=commit_list[2],
-        hunks=commit_list[3],
-        hunk_count=commit_list[4],
-        message=commit_list[5],
-        diff=commit_list[6],
-        changed_files=commit_list[7],
-        message_reference_content=commit_list[8],
-        jira_refs=commit_list[9],
-        ghissue_refs=commit_list[10],
-        cve_refs=commit_list[11],
-        tags=commit_list[12],
-    )
-    return commit_obj
 
     # def format(self):
     #     out = "Commit: {} {}".format(self.repository.get_url(), self.commit_id)


### PR DESCRIPTION
This is my concept on using preprocessed commits from the backend. Related issue #167
Unfortunately the cli module gives me import errors  which I could not fix. 
More specifically:
I invoked the cli tool by: `python client/cli/main.py CVE-2014-0050 --repository https://github.com/apache/commons-fileupload --use-nvd` and got `Traceback (most recent call last):
  File "client/cli/main.py", line 14, in <module>
    from client.cli.prospector_client import (
ModuleNotFoundError: No module named 'client'`
Then when I removed client/cli from the import path in line 8 from main.py, it worked, but then failed at line 8 in prospector_client.py with import error.
I also tried the pytest for client, with the same result.

@copernico can you try it? What am I missing?