### PR TITLE
Feature/report unavailable urls from advisory records

### DIFF
--- a/prospector/commit_processor/feature_extractor.py
+++ b/prospector/commit_processor/feature_extractor.py
@@ -1,4 +1,3 @@
-import functools
 from urllib.parse import urlparse
 
 import requests_cache
@@ -164,12 +163,7 @@ def extract_referred_to_by_pages_linked_from_advisories(
     )
     session = requests_cache.CachedSession("requests-cache")
 
-    def is_commit_cited_in(reference: str, commit_id: str):
+    def is_commit_cited_in(reference: str):
         return commit.commit_id[:8] in session.get(reference).text
 
-    return any(
-        filter(
-            functools.partial(is_commit_cited_in, commit_id=commit.commit_id[:8]),
-            allowed_references,
-        )
-    )
+    return any(filter(is_commit_cited_in, allowed_references))

--- a/prospector/commit_processor/feature_extractor.py
+++ b/prospector/commit_processor/feature_extractor.py
@@ -1,3 +1,4 @@
+import traceback
 from urllib.parse import urlparse
 
 import requests_cache
@@ -164,6 +165,11 @@ def extract_referred_to_by_pages_linked_from_advisories(
     session = requests_cache.CachedSession("requests-cache")
 
     def is_commit_cited_in(reference: str):
-        return commit.commit_id[:8] in session.get(reference).text
+        try:
+            return commit.commit_id[:8] in session.get(reference).text
+        except Exception:
+            print(f"can not retrive site: {reference}")
+            traceback.print_exc()  # TODO: shoud be at debug level logging, but it requires some logging system
+            return False
 
     return any(filter(is_commit_cited_in, allowed_references))

--- a/prospector/commit_processor/feature_extractor.py
+++ b/prospector/commit_processor/feature_extractor.py
@@ -1,3 +1,4 @@
+import functools
 from urllib.parse import urlparse
 
 import requests_cache
@@ -158,9 +159,13 @@ def extract_referred_to_by_pages_linked_from_advisories(
         advisory_record.references,
     )
     session = requests_cache.CachedSession("requests-cache")
+
+    def is_commit_cited_in(reference: str, commit_id: str):
+        return commit.commit_id[:8] in session.get(reference).text
+
     return any(
         filter(
-            lambda reference: commit.commit_id[:8] in session.get(reference).text,
+            functools.partial(is_commit_cited_in, commit_id=commit.commit_id[:8]),
             allowed_references,
         )
     )

--- a/prospector/commit_processor/requests_filter.py
+++ b/prospector/commit_processor/requests_filter.py
@@ -3,4 +3,5 @@ ALLOWED_SITES = [
     "lists.apache.org",
     "just.an.example.site",
     "one.more.example.site",
+    "jvndb.jvm.jp",  # for testing only
 ]

--- a/prospector/commit_processor/requests_filter.py
+++ b/prospector/commit_processor/requests_filter.py
@@ -3,5 +3,6 @@ ALLOWED_SITES = [
     "lists.apache.org",
     "just.an.example.site",
     "one.more.example.site",
-    "jvndb.jvm.jp",  # for testing only
+    "non-existing-url.com",  # for testing.
+    "jvndb.jvn.jp",  # for trying out: usually does not aviable, but not always, anyway it is a good example
 ]

--- a/prospector/commit_processor/test_feature_extractor.py
+++ b/prospector/commit_processor/test_feature_extractor.py
@@ -284,3 +284,18 @@ def test_extract_referred_to_by_pages_linked_from_advisories(repository, request
     assert not extract_referred_to_by_pages_linked_from_advisories(
         commit, advisory_record
     )
+
+
+def test_extract_referred_to_by_pages_linked_from_advisories_wrong_url(repository):
+    advisory_record = AdvisoryRecord(
+        vulnerability_id="CVE-2020-26258",
+        references=["https://non-existing-url.com"],
+    )
+
+    commit = Commit(
+        commit_id="r97993e3d78e1f5389b7b172ba9f308440830ce5",
+        repository="test_repository",
+    )
+    assert not extract_referred_to_by_pages_linked_from_advisories(
+        commit, advisory_record
+    )

--- a/prospector/git/git.py
+++ b/prospector/git/git.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import traceback
 from datetime import datetime
 
 # from pprint import pprint
@@ -273,7 +274,8 @@ class Git:
             path.reverse()
             return path
         except:
-            print("Failed to obtain commits")
+            print("Failed to obtain commits, details below:")
+            traceback.print_exc()
             return []
 
     def get_commit(self, key, by="id"):

--- a/prospector/git/git.py
+++ b/prospector/git/git.py
@@ -275,7 +275,7 @@ class Git:
             return path
         except:
             print("Failed to obtain commits, details below:")
-            traceback.print_exc()
+            traceback.print_exc()  # TODO: shoud be at debug level logging, but it requires some logging system
             return []
 
     def get_commit(self, key, by="id"):


### PR DESCRIPTION
Report unavailable URLs and continue with the next step in the process without killing the CLI. Fix for #189