### PR TITLE
Feature/geryxyz/sap#195/multi level logging

### DIFF
--- a/prospector/client/cli/main.py
+++ b/prospector/client/cli/main.py
@@ -7,7 +7,6 @@ import logging
 import os
 import sys
 from pathlib import Path
-from pprint import pprint
 
 import requests
 
@@ -201,6 +200,7 @@ def main(argv):  # noqa: C901
         log.config.level = getattr(logging, args.log_level)
 
     logger = log.util.init_local_logger()
+    logger.info(f"global log level is set to {logging.getLevelName(log.config.level)}")
 
     if args.vulnerability_id is None:
         logger.error("No vulnerability id was specified. Cannot proceed.")
@@ -250,19 +250,14 @@ def main(argv):  # noqa: C901
     if configuration["global"].get("git_cache"):
         git_cache = configuration["global"].get("git_cache")
 
-    if log.config.level < logging.INFO:
-        print("Using the following configuration:")
-        pprint(
-            {
-                section: dict(configuration[section])
-                for section in configuration.sections()
-            }
-        )
+    logger.debug("Using the following configuration:")
+    logger.pretty_log(
+        {section: dict(configuration[section]) for section in configuration.sections()}
+    )
 
-    if log.config.level < logging.INFO:
-        print("Vulnerability ID: " + vulnerability_id)
-        print("time-limit before: " + str(time_limit_before))
-        print("time-limit after: " + str(time_limit_after))
+    logger.debug("Vulnerability ID: " + vulnerability_id)
+    logger.debug("time-limit before: " + str(time_limit_before))
+    logger.debug("time-limit after: " + str(time_limit_after))
 
     results = prospector(
         vulnerability_id=vulnerability_id,

--- a/prospector/client/cli/main.py
+++ b/prospector/client/cli/main.py
@@ -202,8 +202,6 @@ def main(argv):  # noqa: C901
     logger = log.util.init_local_logger()
     logger.info(f"global log level is set to {logging.getLevelName(log.config.level)}")
 
-    logger.error("something")
-
     if args.vulnerability_id is None:
         logger.error("No vulnerability id was specified. Cannot proceed.")
         return False

--- a/prospector/client/cli/main.py
+++ b/prospector/client/cli/main.py
@@ -11,6 +11,8 @@ from pprint import pprint
 
 import requests
 
+import log.config
+import log.util
 from client.cli.prospector_client import (
     MAX_CANDIDATES,
     TIME_LIMIT_AFTER,
@@ -21,8 +23,6 @@ from datamodel.commit_features import CommitWithFeatures
 from git.git import GIT_CACHE
 
 DEFAULT_BACKEND = "http://localhost:8000"
-
-logger = logging.getLogger("prospector")
 
 # VERSION = '0.1.0'
 # SCRIPT_PATH=os.path.dirname(os.path.realpath(__file__))
@@ -90,14 +90,11 @@ def parseArguments(args):
     )
 
     parser.add_argument(
-        "-v", "--verbose", help="increase output verbosity", action="store_true"
-    )
-
-    parser.add_argument(
-        "-d",
-        "--debug",
-        help="increase output verbosity even more and output stack-traces on exceptions",
-        action="store_true",
+        "-l",
+        "--log-level",
+        dest="log_level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level",
     )
 
     return parser.parse_args(args[1:])
@@ -200,28 +197,22 @@ def main(argv):  # noqa: C901
     args = parseArguments(argv)
     configuration = getConfiguration(args.conf)
 
+    if args.log_level:
+        log.config.level = getattr(logging, args.log_level)
+
+    logger = log.util.init_local_logger()
+
     if args.vulnerability_id is None:
-        print("No vulnerability id was specified. Cannot proceed.")
+        logger.error("No vulnerability id was specified. Cannot proceed.")
         return False
 
     if configuration is None:
-        print("Invalid configuration, exiting.")
+        logger.error("Invalid configuration, exiting.")
         return False
-
-    debug = configuration["global"].getboolean("debug")
-    if args.debug:
-        debug = args.debug
-
-    verbose = configuration["global"].getboolean("verbose")
-    if args.verbose:
-        verbose = args.verbose
 
     report = configuration["global"].getboolean("report")
     if args.report:
         report = args.report
-
-    if debug:
-        verbose = True
 
     if configuration["global"].get("nvd_rest_endpoint"):
         nvd_rest_endpoint = configuration["global"].get("nvd_rest_endpoint")
@@ -231,7 +222,7 @@ def main(argv):  # noqa: C901
         backend = args.backend
 
     if args.ping:
-        return ping_backend(backend, verbose)
+        return ping_backend(backend, log.config.level < logging.INFO)
 
     vulnerability_id = args.vulnerability_id
     repository_url = args.repository
@@ -259,7 +250,7 @@ def main(argv):  # noqa: C901
     if configuration["global"].get("git_cache"):
         git_cache = configuration["global"].get("git_cache")
 
-    if verbose:
+    if log.config.level < logging.INFO:
         print("Using the following configuration:")
         pprint(
             {
@@ -268,7 +259,7 @@ def main(argv):  # noqa: C901
             }
         )
 
-    if verbose:
+    if log.config.level < logging.INFO:
         print("Vulnerability ID: " + vulnerability_id)
         print("time-limit before: " + str(time_limit_before))
         print("time-limit after: " + str(time_limit_after))
@@ -287,20 +278,19 @@ def main(argv):  # noqa: C901
         nvd_rest_endpoint=nvd_rest_endpoint,
         backend_address=backend,
         git_cache=git_cache,
-        verbose=verbose,
-        debug=debug,
+        log_level=log.config.level,
         limit_candidates=max_candidates,
     )
 
     if report == "console":
-        make_report_console(results, verbose=verbose)
+        make_report_console(results, verbose=log.config.level < logging.INFO)
     elif report == "json":
         make_report_json(results)
     elif report == "html":
         make_report_html(results)
     else:
         print("Invalid report type specified, using 'console'")
-        make_report_console(results, verbose=verbose)
+        make_report_console(results, verbose=log.config.level < logging.INFO)
 
     return True
 

--- a/prospector/client/cli/main.py
+++ b/prospector/client/cli/main.py
@@ -202,6 +202,8 @@ def main(argv):  # noqa: C901
     logger = log.util.init_local_logger()
     logger.info(f"global log level is set to {logging.getLevelName(log.config.level)}")
 
+    logger.error("something")
+
     if args.vulnerability_id is None:
         logger.error("No vulnerability id was specified. Cannot proceed.")
         return False

--- a/prospector/client/cli/prospector_client.py
+++ b/prospector/client/cli/prospector_client.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 from datetime import datetime
-from pprint import pprint
 
 import requests
 from tqdm import tqdm
@@ -58,8 +57,7 @@ def prospector(  # noqa: C901
         nvd_rest_endpoint=nvd_rest_endpoint,
     )
 
-    if logger.isEnabledFor(logging.DEBUG):
-        pprint(advisory_record)
+    logger.pretty_log(advisory_record)
 
     advisory_record.analyze(use_nvd=use_nvd)
     print(advisory_record.code_tokens)
@@ -186,10 +184,7 @@ def prospector(  # noqa: C901
     # invoke predict
 
     # TODO here the preprocessed commits should be saved into the database
-
-    if logger.isEnabledFor(logging.DEBUG):
-        # TODO: pprint has to be extracted into logging util
-        pprint(advisory_record)
+    logger.pretty_log(advisory_record)
 
     logger.debug(f"preprocessed {len(preprocessed_commits)} commits")
 

--- a/prospector/log/config.py
+++ b/prospector/log/config.py
@@ -1,0 +1,3 @@
+import logging
+
+level: int = logging.INFO

--- a/prospector/log/util.py
+++ b/prospector/log/util.py
@@ -1,0 +1,24 @@
+import inspect
+import logging
+
+import log.config
+
+
+def init_local_logger():
+    previous_frame = inspect.currentframe().f_back
+    logger_name = "main"
+    if previous_frame:
+        logger_name = inspect.getmodule(previous_frame).__name__
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(log.config.level)
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter(
+            "[%(levelname)s FROM %(name)s] %(message)s\n"
+            "\tIN %(funcName)s (%(filename)s:%(lineno)d)"
+            "\tAT %(asctime)s",
+            "%Y-%m-%d %H:%M:%S",
+        )
+    )
+    logger.addHandler(handler)
+    return logger

--- a/prospector/log/util.py
+++ b/prospector/log/util.py
@@ -1,7 +1,13 @@
 import inspect
 import logging
+from pprint import pformat
 
 import log.config
+
+
+def pretty_log(self: logging.Logger, obj, level: int = logging.DEBUG):
+    as_text = pformat(obj)
+    self.log(level, "detailed content of the object\n" + as_text)
 
 
 def init_local_logger():
@@ -14,11 +20,14 @@ def init_local_logger():
     handler = logging.StreamHandler()
     handler.setFormatter(
         logging.Formatter(
-            "[%(levelname)s FROM %(name)s] %(message)s\n"
-            "\tIN %(funcName)s (%(filename)s:%(lineno)d)"
-            "\tAT %(asctime)s",
+            "[%(levelname)s FROM %(name)s] %(message)s"
+            "\n\tIN %(funcName)s (%(filename)s:%(lineno)d)"
+            "\n\tAT %(asctime)s",
             "%Y-%m-%d %H:%M:%S",
         )
     )
     logger.addHandler(handler)
+
+    setattr(logging.Logger, pretty_log.__name__, pretty_log)
+
     return logger

--- a/prospector/log/util.py
+++ b/prospector/log/util.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import logging.handlers
 from pprint import pformat
 
 import log.config
@@ -17,16 +18,30 @@ def init_local_logger():
         logger_name = inspect.getmodule(previous_frame).__name__
     logger = logging.getLogger(logger_name)
     logger.setLevel(log.config.level)
-    handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(
-            "[%(levelname)s FROM %(name)s] %(message)s"
-            "\n\tIN %(funcName)s (%(filename)s:%(lineno)d)"
-            "\n\tAT %(asctime)s",
-            "%Y-%m-%d %H:%M:%S",
-        )
+    formatter = logging.Formatter(
+        "[%(levelname)s FROM %(name)s] %(message)s"
+        "\n\tIN %(funcName)s (%(filename)s:%(lineno)d)"
+        "\n\tAT %(asctime)s",
+        "%Y-%m-%d %H:%M:%S",
     )
-    logger.addHandler(handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    error_file = logging.handlers.TimedRotatingFileHandler(
+        "error.log", when="h", backupCount=5
+    )
+    error_file.setLevel(logging.ERROR)
+    error_file.setFormatter(formatter)
+    logger.addHandler(error_file)
+
+    all_file = logging.handlers.TimedRotatingFileHandler(
+        "all.log", when="h", backupCount=5
+    )
+    all_file.setLevel(logging.DEBUG)
+    all_file.setFormatter(formatter)
+    logger.addHandler(all_file)
 
     setattr(logging.Logger, pretty_log.__name__, pretty_log)
 

--- a/prospector/log/util.py
+++ b/prospector/log/util.py
@@ -19,7 +19,8 @@ def init_local_logger():
     logger = logging.getLogger(logger_name)
     logger.setLevel(log.config.level)
     formatter = logging.Formatter(
-        "[%(levelname)s FROM %(name)s] %(message)s"
+        "%(message)s"
+        "\n\tOF %(levelname)s FROM %(name)s"
         "\n\tIN %(funcName)s (%(filename)s:%(lineno)d)"
         "\n\tAT %(asctime)s",
         "%Y-%m-%d %H:%M:%S",


### PR DESCRIPTION
Introducing multi-level logging. Fix for #195.

1. logging related utils and settings were extracted into a separate package `log`.
2. support for init local loggers with common setting (project-wide)
3. setting the log level based on CLI args, the default is INFO
4. extracting and integrating pretty print utils into loggers. (There is no feature for custom `Logger` class, hence I added this method dynamically, which prevents the IntelliSense to suggest this method on the `Logger` class, but the methods are there.)
5. replacing several `print` calls with new logging logic to serve as examples.