### PR TITLE
Feature/geryxyz/sap#200/path extraction from comment

### DIFF
--- a/prospector/datamodel/advisory.py
+++ b/prospector/datamodel/advisory.py
@@ -113,7 +113,7 @@ def extract_camelcase_tokens(text) -> "list[str]":
     # return["blaHlafaHlsafs"]
 
 
-def extract_path_tokens(text: str) -> "list[str]":
+def extract_path_tokens(text: str, strict_extensions: bool = False) -> List[str]:
     """
     Used to look for paths in the text (i.e. vulnerability description)
 
@@ -123,15 +123,28 @@ def extract_path_tokens(text: str) -> "list[str]":
     Returns:
         list: a list of paths that are found
     """
-    return [
-        re.split(r"\.|,|/", token.rstrip(r".,;:?!\"'"))
-        for token in text.split(" ")
-        if ("/" in token.rstrip(r".,;:?!\"'") and not token.startswith("</"))
-        or (
-            "." in token.rstrip(r".,;:?!\"'")
-            and token.rstrip(r".,;:?!\"'").split(".")[-1] in RELEVANT_EXTENSIONS
+    tokens = re.split(r"\s+", text)  # split the text into words
+    tokens = [
+        token.strip(",.:;-+!?)]}'\"") for token in tokens
+    ]  # removing common punctuation marks
+    paths = []
+    for token in tokens:
+        is_contains_path_separators = ("\\" in token) or ("/" in token)
+        is_period_separated = "." in token
+        has_relevant_extension = token.split(".")[-1] in RELEVANT_EXTENSIONS
+        is_xml_tag = token.startswith("<")
+        is_property = token.endswith("=")
+
+        # if strict_extensions:
+        # it will always match tokens with (back) slashes,
+        # but it will only match single file names if they have the correct extension
+        is_path_like = is_contains_path_separators or (
+            has_relevant_extension if strict_extensions else is_period_separated
         )
-    ]
+        is_path_dislike = is_xml_tag or is_property
+        if is_path_like and not is_path_dislike:
+            paths.append(token)
+    return paths
 
 
 @dataclass

--- a/prospector/datamodel/advisory.py
+++ b/prospector/datamodel/advisory.py
@@ -119,6 +119,8 @@ def extract_path_tokens(text: str, strict_extensions: bool = False) -> List[str]
 
     Input:
         text (str)
+        strict_extensions (bool): this function will always extract tokens with (back) slashes,
+            but it will only match single file names if they have the correct extension, if this argument is True
 
     Returns:
         list: a list of paths that are found
@@ -129,20 +131,17 @@ def extract_path_tokens(text: str, strict_extensions: bool = False) -> List[str]
     ]  # removing common punctuation marks
     paths = []
     for token in tokens:
-        is_contains_path_separators = ("\\" in token) or ("/" in token)
-        is_period_separated = "." in token
+        contains_path_separators = ("\\" in token) or ("/" in token)
+        separated_with_period = "." in token
         has_relevant_extension = token.split(".")[-1] in RELEVANT_EXTENSIONS
         is_xml_tag = token.startswith("<")
         is_property = token.endswith("=")
 
-        # if strict_extensions:
-        # it will always match tokens with (back) slashes,
-        # but it will only match single file names if they have the correct extension
-        is_path_like = is_contains_path_separators or (
-            has_relevant_extension if strict_extensions else is_period_separated
+        is_path = contains_path_separators or (
+            has_relevant_extension if strict_extensions else separated_with_period
         )
-        is_path_dislike = is_xml_tag or is_property
-        if is_path_like and not is_path_dislike:
+        probably_not_path = is_xml_tag or is_property
+        if is_path and not probably_not_path:
             paths.append(token)
     return paths
 

--- a/prospector/datamodel/advisory_test.py
+++ b/prospector/datamodel/advisory_test.py
@@ -1,5 +1,5 @@
 # from dataclasses import asdict
-from datamodel.advisory import AdvisoryRecord
+from datamodel.advisory import AdvisoryRecord, extract_path_tokens
 
 # import pytest
 
@@ -24,7 +24,7 @@ ADVISORY_TEXT = """Unspecified vulnerability in Uconnect before 15.26.1, as used
 
 ADVISORY_TEXT_2 = """
 In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize
-with an improper input string, like "//../foo", or "\\..\foo", the result would be
+with an improper input string, like "//../foo", or "\\..\\foo", the result would be
 the same value, thus possibly providing access to files in the parent directory,
 but not further above (thus "limited" path traversal), if the calling code would
 use the result to construct a path value."""
@@ -65,3 +65,29 @@ def test_adv_record_code_tokens():
 
     print(record)
     assert "FileNameUtils" in record.code_tokens
+
+
+def test_adv_record_path_extraction_no_real_paths():
+    result = extract_path_tokens(ADVISORY_TEXT)
+
+    assert result == ["15.26.1", '\\"Radio', "protection,\\"]
+
+
+def test_adv_record_path_extraction_has_real_paths():
+    result = extract_path_tokens(ADVISORY_TEXT_2)
+
+    assert result == ["2.7", "FileNameUtils.normalize", "//../foo", "\\..\\foo"]
+
+
+def test_adv_record_path_extraction_strict_extensions():
+    """
+    If strict_extensions is True, it will always extract tokens with (back) slashes,
+    but it will only collect single file names if they have the correct extension.
+    """
+    result = extract_path_tokens(
+        ADVISORY_TEXT_2
+        + " Developer.gery put something here to check if foo.java and bar.cpp will be found.",
+        strict_extensions=True,
+    )
+
+    assert result == ["//../foo", "\\..\\foo", "foo.java", "bar.cpp"]


### PR DESCRIPTION
Refactoring path extraction from the advisory record and fixing its return type. Fix for #200.