### PR TITLE
Add more details to HTML report

### DIFF
--- a/prospector/client/cli/html_report.py
+++ b/prospector/client/cli/html_report.py
@@ -15,9 +15,11 @@ def report_as_html(
     advisory_record: AdvisoryRecord,
     filename: str = "prospector-report.html",
 ):
-    annotations = set()
+    annotations_count = {}
+    commit_with_feature: CommitWithFeatures
     for commit_with_feature in results:
-        annotations = annotations.union(commit_with_feature.annotations.keys())
+        for annotation in commit_with_feature.annotations.keys():
+            annotations_count[annotation] = annotations_count.get(annotation, 0) + 1
 
     _logger.info("Writing results to " + filename)
     environment = jinja2.Environment(
@@ -28,7 +30,7 @@ def report_as_html(
     with open(filename, "w", encoding="utf8") as html_file:
         for content in template.generate(
             candidates=results,
-            present_annotations=annotations,
+            present_annotations=annotations_count,
             advisory_record=advisory_record,
         ):
             html_file.write(content)

--- a/prospector/client/cli/html_report_test.py
+++ b/prospector/client/cli/html_report_test.py
@@ -70,16 +70,29 @@ SUFFIX = [".hu", ".com", ".org", ".ru", ".fr", ".de"]
 
 
 def random_url(max_length: int):
-    return (
-        choice(PROTOCOLS)
-        + "/".join(
-            map(
-                lambda s: s.lower().replace(" ", "-"),
-                random_list_of_strs(min_count=1, max_count=max_length),
+    if random_bool():
+        return (
+            choice(PROTOCOLS)
+            + "/".join(
+                map(
+                    lambda s: s.lower().replace(" ", "-"),
+                    random_list_of_strs(min_count=1, max_count=max_length),
+                )
             )
+            + choice(SUFFIX)
         )
-        + choice(SUFFIX)
-    )
+    else:
+        return (
+            choice(PROTOCOLS)
+            + "github.com/FrontEndART/project-kb"
+            + "/".join(
+                map(
+                    lambda s: s.lower().replace(" ", "-"),
+                    random_list_of_strs(min_count=1, max_count=max_length),
+                )
+            )
+            + choice(SUFFIX)
+        )
 
 
 def random_list_of_url(max_length: int, max_count: int):

--- a/prospector/client/cli/html_report_test.py
+++ b/prospector/client/cli/html_report_test.py
@@ -119,6 +119,16 @@ def random_list_of_github_issue_ids(stop: int, max_count: int, start: int = 0):
     return [str(randint(start, stop)) for _ in range(randint(0, max_count))]
 
 
+def random_version(max_length: int, max_size: int, min_size: int = 0):
+    return ".".join([str(randint(min_size, max_size)) for _ in range(max_length)])
+
+
+def random_list_of_version(
+    max_count: int, max_length: int, max_size: int, min_size: int = 0
+):
+    return [random_version(max_length, max_size, min_size) for _ in range(max_count)]
+
+
 def test_report_generation():
     candidates = []
     for _ in range(100):
@@ -147,14 +157,26 @@ def test_report_generation():
         )
         candidates.append(commit_with_feature)
 
+    advisory = AdvisoryRecord(
+        vulnerability_id=random_list_of_cve(max_count=1, min_count=1)[0],
+        repository_url=random_url(4),
+        published_timestamp=randint(0, 100000),
+        last_modified_timestamp=randint(0, 100000),
+        references=random_list_of_strs(42),
+        references_content=random_list_of_strs(42),
+        advisory_references=random_list_of_cve(42),
+        affected_products=random_list_of_strs(42),
+        description=" ".join(random_list_of_strs(42)),
+        preprocessed_vulnerability_description=" ".join(random_list_of_strs(42)),
+        relevant_tags=random_list_of_strs(42),
+        versions=random_list_of_version(42, 4, 42),
+        from_nvd=random_bool(),
+        paths=random_list_of_path(4, 42),
+        code_tokens=random_list_of_strs(42),
+    )
+
     filename = "test_report.html"
     if os.path.isfile(filename):
         os.remove(filename)
-    generated_report = report_as_html(
-        candidates,
-        AdvisoryRecord(
-            vulnerability_id=random_list_of_cve(max_count=1, min_count=1)[0]
-        ),
-        filename,
-    )
+    generated_report = report_as_html(candidates, advisory, filename)
     assert os.path.isfile(generated_report)

--- a/prospector/client/cli/templates/base.html
+++ b/prospector/client/cli/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" style="height: 100%">
 
 <head>
     <!-- Required meta tags -->
@@ -25,7 +25,7 @@
     <title>{% block title %}Prospector Report{% endblock %}</title>
 </head>
 
-<body>
+<body style="height: 100%">
     {% block content %}
     {% endblock %}
 

--- a/prospector/client/cli/templates/card/annotations_block.html
+++ b/prospector/client/cli/templates/card/annotations_block.html
@@ -1,0 +1,15 @@
+{% extends "titled_block.html" %}
+{% set title = "Annotations" %}
+{% set icon = "fas fa-bullhorn" %}
+{% block body %}
+<p>
+    {% for annotation, comment in commit_with_feature.annotations.items() | sort %}
+    <button type="button" class="btn btn-primary position-relative m-2" disabled>
+        {{ comment }}
+        <span class="position-absolute top-0 start-50 translate-middle badge rounded-pill bg-light border border-primary text-primary">
+            {{ annotation }}
+        </span>
+    </button>
+    {% endfor %}
+</p>
+{% endblock %}

--- a/prospector/client/cli/templates/card/changed_paths_block.html
+++ b/prospector/client/cli/templates/card/changed_paths_block.html
@@ -1,0 +1,10 @@
+{% extends "titled_block.html" %}
+{% set title = "Changed files in commit" %}
+{% set icon = "fas fa-file-signature" %}
+{% block body %}
+<p>
+    {% for path in commit_with_feature.commit.changed_files %}
+    <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ path }}</span>
+    {% endfor %}
+</p>
+{% endblock %}

--- a/prospector/client/cli/templates/card/commit_header.html
+++ b/prospector/client/cli/templates/card/commit_header.html
@@ -1,0 +1,25 @@
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <h5 class="mb-0">
+                {{ commit_with_feature.commit.message | truncate(150) }}
+                {% if not commit_with_feature.commit.message %}
+                <i>(no commit message found)</i>
+                {% endif %}
+            </h5>
+        <p style="margin: 10pt 0 0;">
+            <i class="fas fa-bullhorn"></i>
+            {% for annotation, comment in commit_with_feature.annotations.items() | sort %}
+                <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ annotation }}</span>
+            {% endfor %}
+        </p>
+        </div>
+        <div class="col col-auto">
+            <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
+                data-bs-target="#candidatebody-{{ loop.index }}" aria-expanded="false"
+                aria-controls="collapseExample">
+                <i class="fas fa-low-vision"></i>
+            </button>
+        </div>
+    </div>
+</div>

--- a/prospector/client/cli/templates/card/commit_title_block.html
+++ b/prospector/client/cli/templates/card/commit_title_block.html
@@ -1,0 +1,9 @@
+<h5 class="card-title">
+    <i class="fas fa-code-branch"></i> {{ commit_with_feature.commit.commit_id }}
+    <a href="{{ commit_with_feature.commit.repository }}/commit/{{ commit_with_feature.commit.commit_id }}"
+    target="_blank" class="btn btn-primary btn-sm">Open (assume GitHub like interface)</a>
+</h5>
+<h6 class="card-subtitle mb-2 text-muted">
+    <i class="fab fa-git-alt"></i> {{ commit_with_feature.commit.repository }}
+    <a href="{{ commit_with_feature.commit.repository }}" target="_blank" class="btn btn-primary btn-sm">Open</a>
+</h6>

--- a/prospector/client/cli/templates/card/commit_title_block.html
+++ b/prospector/client/cli/templates/card/commit_title_block.html
@@ -1,9 +1,19 @@
 <h5 class="card-title">
     <i class="fas fa-code-branch"></i> {{ commit_with_feature.commit.commit_id }}
-    <a href="{{ commit_with_feature.commit.repository }}/commit/{{ commit_with_feature.commit.commit_id }}"
-    target="_blank" class="btn btn-primary btn-sm">Open (assume GitHub like interface)</a>
 </h5>
 <h6 class="card-subtitle mb-2 text-muted">
     <i class="fab fa-git-alt"></i> {{ commit_with_feature.commit.repository }}
-    <a href="{{ commit_with_feature.commit.repository }}" target="_blank" class="btn btn-primary btn-sm">Open</a>
+    {% if 'github' in commit_with_feature.commit.repository %}
+    <a
+        href="{{ commit_with_feature.commit.repository }}/commit/{{ commit_with_feature.commit.commit_id }}"
+        target="_blank"
+        class="btn btn-primary btn-sm"
+    >Open Commit (assume GitHub-like API)</a>
+    {% else %}
+    <a
+        href="{{ commit_with_feature.commit.repository }}"
+        target="_blank"
+        class="btn btn-primary btn-sm"
+    >Open Repository (unknown API)</a>
+    {% endif %}
 </h6>

--- a/prospector/client/cli/templates/card/mentioned_cves_block.html
+++ b/prospector/client/cli/templates/card/mentioned_cves_block.html
@@ -1,0 +1,12 @@
+{% extends "titled_block.html" %}
+{% set title = "Other CVEs mentioned in message" %}
+{% set icon = "fas fa-shield-alt" %}
+{% block body %}
+<p>
+    {% for cve in commit_with_feature.other_CVE_in_message %}
+    <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve }}" target="_blank"
+        class="btn btn-outline-primary btn-sm" style="margin: 2pt;">{{
+        cve }}</a>
+    {% endfor %}
+</p>
+{% endblock %}

--- a/prospector/client/cli/templates/card/message_block.html
+++ b/prospector/client/cli/templates/card/message_block.html
@@ -2,5 +2,6 @@
 {% set title = "Commit message" %}
 {% set icon = "fas fa-quote-left" %}
 {% block body %}
-<pre class="card-text">{{ commit_with_feature.commit.message }}</pre>
+<pre
+    class="card-text" style="white-space: pre-wrap;">{{ commit_with_feature.commit.message }}</pre>
 {% endblock %}

--- a/prospector/client/cli/templates/card/message_block.html
+++ b/prospector/client/cli/templates/card/message_block.html
@@ -1,0 +1,6 @@
+{% extends "titled_block.html" %}
+{% set title = "Commit message" %}
+{% set icon = "fas fa-quote-left" %}
+{% block body %}
+<pre class="card-text">{{ commit_with_feature.commit.message }}</pre>
+{% endblock %}

--- a/prospector/client/cli/templates/card/message_block.html
+++ b/prospector/client/cli/templates/card/message_block.html
@@ -2,6 +2,5 @@
 {% set title = "Commit message" %}
 {% set icon = "fas fa-quote-left" %}
 {% block body %}
-<pre
-    class="card-text" style="white-space: pre-wrap;">{{ commit_with_feature.commit.message }}</pre>
+<pre class="card-text" style="white-space: pre-wrap;">{{ commit_with_feature.commit.message }}</pre>
 {% endblock %}

--- a/prospector/client/cli/templates/card/pages_linked_from_advisories_block.html
+++ b/prospector/client/cli/templates/card/pages_linked_from_advisories_block.html
@@ -1,0 +1,10 @@
+{% extends "titled_block.html" %}
+{% set title = "Referred by pages linked from advisories" %}
+{% set icon = "fas fa-link" %}
+{% block body %}
+<p>
+    {% for page in commit_with_feature.referred_to_by_pages_linked_from_advisories %}
+    <a href="{{ page }}" class="btn btn-outline-primary btn-sm" style="margin: 2pt;">{{ page }}</a>
+    {% endfor %}
+</p>
+{% endblock %}

--- a/prospector/client/cli/templates/card/relevant_paths_block.html
+++ b/prospector/client/cli/templates/card/relevant_paths_block.html
@@ -1,0 +1,10 @@
+{% extends "titled_block.html" %}
+{% set title = "Path relevant for changes" %}
+{% set icon = "fas fa-file-signature" %}
+{% block body %}
+<p>
+    {% for path in commit_with_feature.changes_relevant_path %}
+    <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ path }}</span>
+    {% endfor %}
+</p>
+{% endblock %}

--- a/prospector/client/cli/templates/collapse_all_scripts.html
+++ b/prospector/client/cli/templates/collapse_all_scripts.html
@@ -1,0 +1,26 @@
+<script type="application/javascript">
+function toggle_collapse_all(selector) {
+    if (selector.classList.contains("btn-primary")) {
+        selector.classList.replace("btn-primary", "btn-outline-primary");
+        selector.innerHTML = 'Expand all';
+    } else {
+        selector.classList.replace( "btn-outline-primary", "btn-primary");
+        selector.innerHTML = 'Collapse all';
+    }
+
+    let commit_cards = document.getElementsByClassName('commit');
+    for (let card of commit_cards) {
+        let card_body = card.getElementsByClassName('collapse').item(0);
+        if (selector.classList.contains('btn-primary')) {
+            card_body.classList.replace('hide', 'show');
+        } else {
+            card_body.classList.replace('show', 'hide');
+        }
+    }
+    console.log("toggle collapse all")
+}
+
+collapse_all_button = document.getElementById('collapse_all_toggle');
+collapse_all_button.addEventListener('click', function() {toggle_collapse_all(collapse_all_button);})
+
+</script>

--- a/prospector/client/cli/templates/filtering_scripts.html
+++ b/prospector/client/cli/templates/filtering_scripts.html
@@ -1,0 +1,34 @@
+<script type="text/javascript">
+buttons = document.getElementsByClassName("selector");
+
+function toggle(selector) {
+    if (selector.classList.contains("btn-primary")) {
+        selector.classList.replace("btn-primary", "btn-outline-primary");
+    } else {
+        selector.classList.replace( "btn-outline-primary", "btn-primary");
+    }
+
+    let commit_cards = document.getElementsByClassName('commit');
+    for (let card of commit_cards) {
+        card.classList.replace("d-flex", "d-none")
+    }
+    let selectors = document.getElementsByClassName("selector");
+    for (const selector of selectors) {
+        if (selector.classList.contains('btn-primary')) {
+            for (let card of commit_cards) {
+                let annotations = JSON.parse(card.dataset.annotations);
+                let relevant = annotations.hasOwnProperty(selector.dataset.annotation);
+                if (relevant) {
+                    card.classList.replace('d-none', 'd-flex')
+                }
+            }
+        }
+    }
+    console.log("toggle: " + selector.dataset.annotation)
+}
+
+for (let i = 0, l = buttons.length; i < l; i++) {
+    let button = buttons[i];
+    button.addEventListener('click', function () {toggle(button);})
+}
+</script>

--- a/prospector/client/cli/templates/report_header.html
+++ b/prospector/client/cli/templates/report_header.html
@@ -4,12 +4,12 @@
         Displaying all items with at least one <button class="btn btn-primary btn-sm">on annotation filter</button>.
         You could toggle the filters between <button class="btn btn-primary btn-sm">on</button> and
         <button class="btn btn-outline-primary btn-sm">off</button> states by left click on them.<br/>
-    {% for annotation in present_annotations | sort %}
+    {% for annotation, count in present_annotations.items() | sort %}
         <button
                 class="btn btn-primary btn-sm selector"
                 style="margin: 5pt 5pt 5pt 0;"
                 data-annotation="{{ annotation }}"
-        >{{ annotation }}</button>
+        >{{ annotation }} <span class="badge bg-secondary">{{ count }}</span></button>
     {% endfor %}
     </p>
     <p>

--- a/prospector/client/cli/templates/report_header.html
+++ b/prospector/client/cli/templates/report_header.html
@@ -1,0 +1,24 @@
+<div class="sticky-top bg-light bg-gradient p-3 mb-3 border border-secondary">
+    <p class="text-center">
+        Displaying all items with at least one <button class="btn btn-primary btn-sm">on annotation filter</button>.
+        You could toggle the filters between <button class="btn btn-primary btn-sm">on</button> and
+        <button class="btn btn-outline-primary btn-sm">off</button> states by left click on them.<br/>
+    {% for annotation in present_annotations | sort %}
+        <button
+                class="btn btn-primary btn-sm selector"
+                style="margin: 5pt 5pt 5pt 0;"
+                data-annotation="{{ annotation }}"
+        >{{ annotation }}</button>
+    {% endfor %}
+    </p>
+    <div class="advisory-record">
+        <h2>Advisory Record</h2>
+        <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b>{{ advisory_record.vulnerability_id }}</b></a><br/>
+        <p>{{ advisory_record.description }}</p>
+        <p style="margin: 10pt 0 0;">
+            {% for code_token in advisory_record.code_tokens | sort %}
+                <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ code_token }}</span>
+            {% endfor %}
+        </p>
+    </div>
+</div>

--- a/prospector/client/cli/templates/report_header.html
+++ b/prospector/client/cli/templates/report_header.html
@@ -12,6 +12,9 @@
         >{{ annotation }}</button>
     {% endfor %}
     </p>
+    <p>
+        <button class="btn btn-primary" id="collapse_all_toggle">Collapse All</button>
+    </p>
     <div class="advisory-record">
         <h2>Results based on this Advisory Record</h2>
         <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b>{{ advisory_record.vulnerability_id }}</b></a><br/>

--- a/prospector/client/cli/templates/report_header.html
+++ b/prospector/client/cli/templates/report_header.html
@@ -1,4 +1,5 @@
-<div class="sticky-top bg-light bg-gradient p-3 mb-3 border border-secondary">
+<div class="col-3 h-100 overflow-scroll bg-light bg-gradient border border-secondary">
+    <h2>Filters</h2>
     <p class="text-center">
         Displaying all items with at least one <button class="btn btn-primary btn-sm">on annotation filter</button>.
         You could toggle the filters between <button class="btn btn-primary btn-sm">on</button> and
@@ -12,7 +13,7 @@
     {% endfor %}
     </p>
     <div class="advisory-record">
-        <h2>Advisory Record</h2>
+        <h2>Results based on this Advisory Record</h2>
         <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b>{{ advisory_record.vulnerability_id }}</b></a><br/>
         <p>{{ advisory_record.description }}</p>
         <p style="margin: 10pt 0 0;">

--- a/prospector/client/cli/templates/results.html
+++ b/prospector/client/cli/templates/results.html
@@ -34,4 +34,5 @@
 </div>
 </div>
 {% include "filtering_scripts.html" %}
+{% include "collapse_all_scripts.html" %}
 {% endblock %}

--- a/prospector/client/cli/templates/results.html
+++ b/prospector/client/cli/templates/results.html
@@ -18,10 +18,11 @@
                 aria-labelledby="candidateheader-{{ loop.index }}" data-parent="#accordion">
                 <div class="card-body">
                     {% include "card/commit_title_block.html" %}
-                    {% include "card/message_block.html" %}
-                    {% include "card/mentioned_cves_block.html" %}
-                    {% include "card/relevant_paths_block.html" %}
                     {% include "card/annotations_block.html" %}
+                    {% include "card/message_block.html" %}
+                    {% include "card/relevant_paths_block.html" %}
+                    {% include "card/changed_paths_block.html" %}
+                    {% include "card/mentioned_cves_block.html" %}
                     {% include "card/pages_linked_from_advisories_block.html" %}
                 </div>
             </div>

--- a/prospector/client/cli/templates/results.html
+++ b/prospector/client/cli/templates/results.html
@@ -1,110 +1,25 @@
 {% extends "base.html" %}
+
 {% block content %}
-
 <div class="container">
+    {% include "report_header.html" %}
+
     <h1>Prospector Report</h1>
-
-    <div class="sticky-top bg-light bg-gradient p-3 mb-3 border border-secondary">
-        <p class="text-center">
-            Displaying all items with at least one <button class="btn btn-primary btn-sm">on annotation filter</button>.
-            You could toggle the filters between <button class="btn btn-primary btn-sm">on</button> and
-            <button class="btn btn-outline-primary btn-sm">off</button> states by left click on them.<br/>
-        {% for annotation in present_annotations | sort %}
-            <button
-                    class="btn btn-primary btn-sm selector"
-                    style="margin: 5pt 5pt 5pt 0;"
-                    data-annotation="{{ annotation }}"
-            >{{ annotation }}</button>
-        {% endfor %}
-        </p>
-        <div class="advisory-record">
-            <h2>Advisory Record</h2>
-            <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b>{{ advisory_record.vulnerability_id }}</b></a><br/>
-            <p>{{ advisory_record.description }}</p>
-            <p style="margin: 10pt 0 0;">
-                {% for code_token in advisory_record.code_tokens | sort %}
-                    <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ code_token }}</span>
-                {% endfor %}
-            </p>
-        </div>
-    </div>
-
     <div id="accordion">
         {% for commit_with_feature in candidates %}
         <div class="card commit d-flex" data-annotations="{{ commit_with_feature.annotations | tojson | forceescape }}">
             <div class="card-header" id="candidateheader{{ loop.index }}">
-                <div class="container">
-                    <div class="row">
-                        <div class="col">
-                            <h5 class="mb-0">
-                                {{ commit_with_feature.commit.message | truncate(150) }}
-                                {% if not commit_with_feature.commit.message %}
-                                <i>(no commit message found)</i>
-                                {% endif %}
-                            </h5>
-                        <p style="margin: 10pt 0 0;">
-                            {% for annotation, comment in commit_with_feature.annotations.items() | sort %}
-                                <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ annotation }}</span>
-                            {% endfor %}
-                        </p>
-                        </div>
-                        <div class="col col-auto">
-                            <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#candidatebody-{{ loop.index }}" aria-expanded="false"
-                                aria-controls="collapseExample">
-                                <i class="fas fa-low-vision"></i>
-                            </button>
-                        </div>
-                    </div>
-                </div>
+                {% include "card/commit_header.html" %}
             </div>
-
             <div id="candidatebody-{{ loop.index }}" class="collapse show"
                 aria-labelledby="candidateheader-{{ loop.index }}" data-parent="#accordion">
                 <div class="card-body">
-                    <h5 class="card-title"><i class="fas fa-code-branch"></i> {{ commit_with_feature.commit.commit_id }}
-                    </h5>
-                    <h6 class="card-subtitle mb-2 text-muted"><i class="fab fa-git-alt"></i> {{
-                        commit_with_feature.commit.repository }} <a href="{{ commit_with_feature.commit.repository }}"
-                            target="_blank" class="btn btn-primary btn-sm">Open</a>
-                            <a href="{{ commit_with_feature.commit.repository }}/commit/{{ commit_with_feature.commit.commit_id }}"
-                            target="_blank" class="btn btn-primary btn-sm">Open (on GitHub)</a>
-                        </h6>
-                    <p class="card-text"><i class="fas fa-quote-left"></i> <pre>{{ commit_with_feature.commit.message
-                        }}</pre><i class="fas fa-quote-right"></i></p>
-
-                    <h5 class="card-title"><i class="fas fa-shield-alt"></i> Other CVEs mentioned in message</h5>
-                    <p>{% for cve in commit_with_feature.other_CVE_in_message %}
-                        <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve }}" target="_blank"
-                            class="btn btn-outline-primary btn-sm" style="margin: 2pt;">{{
-                            cve }}</a>
-                        {% endfor %}
-                    </p>
-
-                    <h5 class="card-title"><i class="fas fa-file-signature"></i> Path relevant for changes</h5>
-                    <p>{% for path in commit_with_feature.changes_relevant_path %}
-                        <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{
-                            path }}</span>
-                        {% endfor %}
-                    </p>
-
-                    <h5 class="card-title"><i class="fas fa-bullhorn"></i> Annotations </h5>
-                    <p>{% for annotation, comment in commit_with_feature.annotations.items() | sort %}
-                        <button type="button" class="btn btn-primary position-relative m-2" disabled>
-                            {{ comment }}
-                            <span class="position-absolute top-0 start-50 translate-middle badge rounded-pill bg-light border border-primary text-primary">
-                                {{ annotation }}
-                            </span>
-                        </button>
-                        {% endfor %}
-                    </p>
-
-                    <h5 class="card-title"><i class="fas fa-link"></i> Referred by pages linked from
-                        advisories</h5>
-                    <p>{% for page in commit_with_feature.referred_to_by_pages_linked_from_advisories %}
-                        <a href="{{ page }}" class="btn btn-outline-primary btn-sm" style="margin: 2pt;">{{
-                            page }}</a> {% endfor %}
-                    </p>
+                    {% include "card/commit_title_block.html" %}
+                    {% include "card/message_block.html" %}
+                    {% include "card/mentioned_cves_block.html" %}
+                    {% include "card/relevant_paths_block.html" %}
+                    {% include "card/annotations_block.html" %}
+                    {% include "card/pages_linked_from_advisories_block.html" %}
                 </div>
             </div>
         </div>
@@ -112,39 +27,5 @@
     </div>
 </div>
 
-<script type="text/javascript">
-buttons = document.getElementsByClassName("selector");
-
-function toggle(selector) {
-    if (selector.classList.contains("btn-primary")) {
-        selector.classList.replace("btn-primary", "btn-outline-primary");
-    } else {
-        selector.classList.replace( "btn-outline-primary", "btn-primary");
-    }
-
-    let commit_cards = document.getElementsByClassName('commit');
-    for (let card of commit_cards) {
-        card.classList.replace("d-flex", "d-none")
-    }
-    let selectors = document.getElementsByClassName("selector");
-    for (const selector of selectors) {
-        if (selector.classList.contains('btn-primary')) {
-            for (let card of commit_cards) {
-                let annotations = JSON.parse(card.dataset.annotations);
-                let relevant = annotations.hasOwnProperty(selector.dataset.annotation);
-                if (relevant) {
-                    card.classList.replace('d-none', 'd-flex')
-                }
-            }
-        }
-    }
-    console.log("toggle: " + selector.dataset.annotation)
-}
-
-for (let i = 0, l = buttons.length; i < l; i++) {
-    let button = buttons[i];
-    button.addEventListener('click', function () {toggle(button);})
-}
-</script>
-
+{% include "filtering_scripts.html" %}
 {% endblock %}

--- a/prospector/client/cli/templates/results.html
+++ b/prospector/client/cli/templates/results.html
@@ -1,11 +1,14 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container">
+<div class="container-fluid h-100">
+<div class="row h-100">
     {% include "report_header.html" %}
 
+<div class="col h-100 overflow-scroll">
+<div class="container">
     <h1>Prospector Report</h1>
-    <div id="accordion">
+    <div id="col accordion">
         {% for commit_with_feature in candidates %}
         <div class="card commit d-flex" data-annotations="{{ commit_with_feature.annotations | tojson | forceescape }}">
             <div class="card-header" id="candidateheader{{ loop.index }}">
@@ -26,6 +29,8 @@
         {% endfor %}
     </div>
 </div>
-
+</div>
+</div>
+</div>
 {% include "filtering_scripts.html" %}
 {% endblock %}

--- a/prospector/client/cli/templates/titled_block.html
+++ b/prospector/client/cli/templates/titled_block.html
@@ -1,0 +1,2 @@
+<h5 class="card-title"><i class="{{ icon }}"></i> {{ title }}</h5>
+{% block body %}empty block{% endblock %}


### PR DESCRIPTION
See #211 
- [x] I know that this is not possible in general, but we should at least detect if the repository is on GitHub (which is true for the overwhelming majority of cases) and just concatenate `repo_url + '/commit/' + commit_id`.
Ideally, we can treat in the same way GitLab and maybe one or two more common cases. For the rest (if any??) the current behavior shall stay.
  - NOTE: right now there is an extra button "open (on Github)" but that is to be considered a temporary hack; eventually we want just one button that does "the right thing"
- [x] full list of modified paths
- [x] full textual description of advisory
- [x] count of matches for each rule (maybe besides the rule button at the top of the page?)
- [x] button to collapse-fold all candidates 
