### PR TITLE
replacing %ct with %at in date extraction from commit and tags

### DIFF
--- a/prospector/git/git.py
+++ b/prospector/git/git.py
@@ -614,7 +614,7 @@ class Commit:
             tag_timestamp = "0"
 
         try:
-            commit_timestamp = self._exec.run('git show -s --format="%ct" ' + self._id)[
+            commit_timestamp = self._exec.run('git show -s --format="%at" ' + self._id)[
                 0
             ][1:-1]
             time_delta = int(tag_timestamp) - int(commit_timestamp)


### PR DESCRIPTION
Replacing %ct with %at to detect the original creation date of the commit, which will be independent of its application into the repositories.

Close #277.