### PR TITLE
Add HTML report select and export, silenced flake8 errors

### DIFF
--- a/prospector/client/cli/main.py
+++ b/prospector/client/cli/main.py
@@ -10,25 +10,24 @@ from pathlib import Path
 
 import requests
 
-# Runtime cannot find local module
 path_root = os.getcwd()
 if path_root not in sys.path:
     sys.path.append(path_root)
 
-import log.config
-import log.util
-from client.cli.console import ConsoleWriter, MessageStatus
-from client.cli.console_report import report_on_console
-from client.cli.html_report import report_as_html
-from client.cli.json_report import report_as_json
-from client.cli.prospector_client import (
-    MAX_CANDIDATES,
-    TIME_LIMIT_AFTER,
-    TIME_LIMIT_BEFORE,
-    prospector,
+import log  # noqa: E402
+
+from client.cli.console import ConsoleWriter, MessageStatus  # noqa: E402
+from client.cli.console_report import report_on_console  # noqa: E402
+from client.cli.html_report import report_as_html  # noqa: E402
+from client.cli.json_report import report_as_json  # noqa: E402
+from client.cli.prospector_client import (  # noqa: E402
+    MAX_CANDIDATES,  # noqa: E402
+    TIME_LIMIT_AFTER,  # noqa: E402
+    TIME_LIMIT_BEFORE,  # noqa: E402
+    prospector,  # noqa: E402
 )
-from git.git import GIT_CACHE
-from stats.execution import execution_statistics
+from git.git import GIT_CACHE  # noqa: E402
+from stats.execution import execution_statistics  # noqa: E402
 
 _logger = log.util.init_local_logger()
 

--- a/prospector/client/cli/templates/base.html
+++ b/prospector/client/cli/templates/base.html
@@ -33,6 +33,13 @@
             padding-left: 0;
         }
 
+        .popuptext {
+            visibility: hidden;
+        }
+
+        .show {
+            visibility: visible;
+        }
     </style>
 
     <title>{% block title %}Prospector Report{% endblock %}</title>

--- a/prospector/client/cli/templates/card/commit_header.html
+++ b/prospector/client/cli/templates/card/commit_header.html
@@ -7,22 +7,23 @@
                 <i>(no commit message found)</i>
                 {% endif %}
             </h5>
-        <p style="margin: 10pt 0 0;">
-            <i class="fas fa-bullhorn"></i>
-            {% for annotation, comment in annotated_commit.annotations.items() | sort %}
+            <p style="margin: 10pt 0 0;">
+                <i class="fas fa-bullhorn"></i>
+                {% for annotation, comment in annotated_commit.annotations.items() | sort %}
                 <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ annotation }}</span>
-            {% endfor %}
-        </p>
+                {% endfor %}
+            </p>
         </div>
         <div class="col col-auto">
             <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
-                data-bs-target="#candidatebody-{{ loop.index }}" aria-expanded="false"
-                aria-controls="collapseExample">
+                data-bs-target="#candidatebody-{{ loop.index }}" aria-expanded="false" aria-controls="collapseExample">
                 <i class="fas fa-low-vision"></i>
             </button>
-            <div class="col col-auto">
-                <input class="card-check-input" type="checkbox" height="100px" width="100px"  onchange="colorChange()"/>
-            </div>        
+        </div>
+        <div class="col col-auto">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" onchange="selectCard()">
+            </div>
         </div>
     </div>
 </div>

--- a/prospector/client/cli/templates/card/commit_header.html
+++ b/prospector/client/cli/templates/card/commit_header.html
@@ -20,6 +20,9 @@
                 aria-controls="collapseExample">
                 <i class="fas fa-low-vision"></i>
             </button>
+            <div class="col col-auto">
+                <input class="card-check-input" type="checkbox" height="100px" width="100px"  onchange="colorChange()"/>
+            </div>        
         </div>
     </div>
 </div>

--- a/prospector/client/cli/templates/card/commit_title_block.html
+++ b/prospector/client/cli/templates/card/commit_title_block.html
@@ -1,7 +1,7 @@
-<h5 class="card-title">
+<h5 id="commit_id" class="card-title">
     <i class="fas fa-code-branch"></i> {{ annotated_commit.commit_id }}
 </h5>
-<h6 class="card-subtitle mb-2 text-muted">
+<h6  id="repository_url" class="card-subtitle mb-2 text-muted">
     <i class="fab fa-git-alt"></i> {{ annotated_commit.repository }}
     {% if 'github' in annotated_commit.repository %}
     <a

--- a/prospector/client/cli/templates/report_header.html
+++ b/prospector/client/cli/templates/report_header.html
@@ -1,58 +1,85 @@
 <div class="col-3 h-100 overflow-scroll bg-light bg-gradient border border-secondary">
     <script>
-        function colorChange(){
+        function selectCard() {
             let hdr = event.target.closest("div.card-header")
-            if(hdr.classList.contains('bg-success')){
+            if (hdr.classList.contains('bg-success')) {
                 hdr.classList.remove('bg-success')
-            }else{
+            } else {
                 hdr.classList.add('bg-success')
             }
         }
 
-        function exportSelected(){
+        function exportToYaml() {
             let list = document.querySelectorAll(".card-header.bg-success")
+            if (list.length == 0) {
+                return ""
+            }
+
             let cve_id = document.getElementById("cve_id").textContent
             let repo_url = document.getElementById("repository_url").textContent.trim().split("\n")[0]
             let out = `vulnerability_id: ${cve_id}\nfixes:\n\tcommits:`
 
-            for(let i=0;i<list.length;i++){
+            for (let i = 0; i < list.length; i++) {
                 let commit_id = list[i].closest('.card').querySelector('#commit_id').textContent.trim()
                 out += `\n\t- id: ${commit_id}\n\t  repository: ${repo_url}\n`
             }
 
-            navigator.clipboard.writeText(out)
-
-            document.getElementById("copy-popup").classList.toggle("show")
-            setTimeout(() => {
-                document.getElementById("copy-popup").classList.toggle("show")
-            }, 1000)
+            return out
         }
-        
+
+        function copyToClipboard() {
+            let text = exportToYaml()
+            try {
+                navigator.clipboard.writeText(text)
+                document.getElementById("copy-popup").classList.toggle("show")
+                setTimeout(() => {
+                    document.getElementById("copy-popup").classList.toggle("show")
+                }, 1000)
+            } catch (err) {
+                console.log('Something went wrong', err);
+            }
+        }
+
+        function downloadAsFile() {
+            let text = exportToYaml()
+            if (text == "") {
+                return
+            }
+            var element = document.createElement('a');
+            element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+            element.setAttribute('download', "exported-commits.yaml");
+
+            element.style.display = 'none';
+            document.body.appendChild(element);
+
+            element.click();
+
+            document.body.removeChild(element);
+        }
     </script>
-    
+
     <h2>Filters</h2>
     <p class="text-center">
         Displaying all items with at least one <button class="btn btn-primary btn-sm">on annotation filter</button>.
         You could toggle the filters between <button class="btn btn-primary btn-sm">on</button> and
-        <button class="btn btn-outline-primary btn-sm">off</button> states by left click on them.<br/>
-    {% for annotation, count in present_annotations.items() | sort %}
-        <button
-                class="btn btn-primary btn-sm selector"
-                style="margin: 5pt 5pt 5pt 0;"
-                data-annotation="{{ annotation }}"
-        >{{ annotation }} <span class="badge bg-secondary">{{ count }}</span></button>
-    {% endfor %}
+        <button class="btn btn-outline-primary btn-sm">off</button> states by left click on them.<br />
+        {% for annotation, count in present_annotations.items() | sort %}
+        <button class="btn btn-primary btn-sm selector" style="margin: 5pt 5pt 5pt 0;"
+            data-annotation="{{ annotation }}">{{ annotation }} <span class="badge bg-secondary">{{ count
+                }}</span></button>
+        {% endfor %}
     </p>
     <p>
         <button class="btn btn-primary" id="collapse_all_toggle">Collapse All</button>
     </p>
     <div class="advisory-record">
         <h2>Results based on this Advisory Record</h2>
-        <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b id="cve_id">{{ advisory_record.vulnerability_id }}</b></a><br/>
+        <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b
+                id="cve_id">{{ advisory_record.vulnerability_id }}</b></a><br />
         <p>{{ advisory_record.description }}</p>
         <p style="margin: 10pt 0 0;">
             {% for token in advisory_record.keywords | sort %}
-                <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ token }}</span>
+            <span class="badge rounded-pill bg-primary" style="font-family: monospace;">{{ token }}</span>
             {% endfor %}
         </p>
     </div>

--- a/prospector/client/cli/templates/report_header.html
+++ b/prospector/client/cli/templates/report_header.html
@@ -1,4 +1,35 @@
 <div class="col-3 h-100 overflow-scroll bg-light bg-gradient border border-secondary">
+    <script>
+        function colorChange(){
+            let hdr = event.target.closest("div.card-header")
+            if(hdr.classList.contains('bg-success')){
+                hdr.classList.remove('bg-success')
+            }else{
+                hdr.classList.add('bg-success')
+            }
+        }
+
+        function exportSelected(){
+            let list = document.querySelectorAll(".card-header.bg-success")
+            let cve_id = document.getElementById("cve_id").textContent
+            let repo_url = document.getElementById("repository_url").textContent.trim().split("\n")[0]
+            let out = `vulnerability_id: ${cve_id}\nfixes:\n\tcommits:`
+
+            for(let i=0;i<list.length;i++){
+                let commit_id = list[i].closest('.card').querySelector('#commit_id').textContent.trim()
+                out += `\n\t- id: ${commit_id}\n\t  repository: ${repo_url}\n`
+            }
+
+            navigator.clipboard.writeText(out)
+
+            document.getElementById("copy-popup").classList.toggle("show")
+            setTimeout(() => {
+                document.getElementById("copy-popup").classList.toggle("show")
+            }, 1000)
+        }
+        
+    </script>
+    
     <h2>Filters</h2>
     <p class="text-center">
         Displaying all items with at least one <button class="btn btn-primary btn-sm">on annotation filter</button>.
@@ -17,7 +48,7 @@
     </p>
     <div class="advisory-record">
         <h2>Results based on this Advisory Record</h2>
-        <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b>{{ advisory_record.vulnerability_id }}</b></a><br/>
+        <a href="https://nvd.nist.gov/vuln/detail/{{ advisory_record.vulnerability_id }}" target="_blank"><b id="cve_id">{{ advisory_record.vulnerability_id }}</b></a><br/>
         <p>{{ advisory_record.description }}</p>
         <p style="margin: 10pt 0 0;">
             {% for token in advisory_record.keywords | sort %}

--- a/prospector/client/cli/templates/results.html
+++ b/prospector/client/cli/templates/results.html
@@ -2,49 +2,53 @@
 
 {% block content %}
 <div class="container-fluid h-100">
-<div class="row h-100">
-    {% include "report_header.html" %}
+    <div class="row h-100">
+        {% include "report_header.html" %}
 
-<div class="col h-100 overflow-scroll">
-<div class="container">
-    <div class="row">
-        <div class="col">
-            <h1>Prospector Report</h1> 
-        </div>
-        <div class="col col-auto align-self-end mb-2">
-            <span class="popuptext" id="copy-popup">Copied to clipboard!</span>
-            <a target="_blank" class="btn btn-primary btn-sm" onclick="exportSelected()">Export selected</a> 
-        </div>
-        
-    </div>
-    <div id="col accordion">
-        {% for annotated_commit in candidates %}
-        <div class="card commit d-flex" data-annotations="{{ annotated_commit.annotations | tojson | forceescape }}">
-            
-            <div class="card-header" id="candidateheader{{ loop.index }}">
-                {% include "card/commit_header.html" %}
-            </div>
-            
-            
+        <div class="col h-100 overflow-scroll">
+            <div class="container">
+                <div class="row">
+                    <div class="col">
+                        <h1>Prospector Report</h1>
+                    </div>
+                    <div class="col col-auto align-self-end mb-2">
+                        <span class="popuptext" id="copy-popup">Copied to clipboard!</span>
+                        <a target="_blank" class="btn btn-primary btn-sm" onclick="copyToClipboard()">Copy
+                            selected</a>
+                        <a target="_blank" class="btn btn-primary btn-sm" onclick="downloadAsFile()">Download
+                            selected</a>
+                    </div>
 
-            <div id="candidatebody-{{ loop.index }}" class="collapse show"
-                aria-labelledby="candidateheader-{{ loop.index }}" data-parent="#accordion">
-                <div class="card-body">
-                    {% include "card/commit_title_block.html" %}
-                    {% include "card/annotations_block.html" %}
-                    {% include "card/message_block.html" %}
-                    {% include "card/relevant_paths_block.html" %}
-                    {% include "card/changed_paths_block.html" %}
-                    {% include "card/mentioned_cves_block.html" %}
-                    {% include "card/pages_linked_from_advisories_block.html" %}
+                </div>
+                <div id="col accordion">
+                    {% for annotated_commit in candidates %}
+                    <div class="card commit d-flex"
+                        data-annotations="{{ annotated_commit.annotations | tojson | forceescape }}">
+
+                        <div class="card-header" id="candidateheader{{ loop.index }}">
+                            {% include "card/commit_header.html" %}
+                        </div>
+
+
+
+                        <div id="candidatebody-{{ loop.index }}" class="collapse show"
+                            aria-labelledby="candidateheader-{{ loop.index }}" data-parent="#accordion">
+                            <div class="card-body">
+                                {% include "card/commit_title_block.html" %}
+                                {% include "card/annotations_block.html" %}
+                                {% include "card/message_block.html" %}
+                                {% include "card/relevant_paths_block.html" %}
+                                {% include "card/changed_paths_block.html" %}
+                                {% include "card/mentioned_cves_block.html" %}
+                                {% include "card/pages_linked_from_advisories_block.html" %}
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
                 </div>
             </div>
         </div>
-        {% endfor %}
     </div>
-</div>
-</div>
-</div>
 </div>
 {% include "filtering_scripts.html" %}
 {% include "collapse_all_scripts.html" %}

--- a/prospector/client/cli/templates/results.html
+++ b/prospector/client/cli/templates/results.html
@@ -7,13 +7,26 @@
 
 <div class="col h-100 overflow-scroll">
 <div class="container">
-    <h1>Prospector Report</h1>
+    <div class="row">
+        <div class="col">
+            <h1>Prospector Report</h1> 
+        </div>
+        <div class="col col-auto align-self-end mb-2">
+            <span class="popuptext" id="copy-popup">Copied to clipboard!</span>
+            <a target="_blank" class="btn btn-primary btn-sm" onclick="exportSelected()">Export selected</a> 
+        </div>
+        
+    </div>
     <div id="col accordion">
         {% for annotated_commit in candidates %}
         <div class="card commit d-flex" data-annotations="{{ annotated_commit.annotations | tojson | forceescape }}">
+            
             <div class="card-header" id="candidateheader{{ loop.index }}">
                 {% include "card/commit_header.html" %}
             </div>
+            
+            
+
             <div id="candidatebody-{{ loop.index }}" class="collapse show"
                 aria-labelledby="candidateheader-{{ loop.index }}" data-parent="#accordion">
                 <div class="card-body">


### PR DESCRIPTION
The HTML report has now two added functionalities, the export is automatically copied on the clipboard.
Initial implementation of #310 

flake8 errors in client/cli/main.py are silenced temporarily
