### PR TITLE
Release of 22 statements (Exact match no twins)

### DIFF
--- a/statements/CVE-2013-0158/statement.yaml
+++ b/statements/CVE-2013-0158/statement.yaml
@@ -1,0 +1,17 @@
+vulnerability_id: CVE-2013-0158
+notes:
+- links: []
+  text: Unspecified vulnerability in Jenkins before 1.498, Jenkins LTS before 1.480.2, and Jenkins Enterprise 1.447.x before 1.447.6.1 and 1.466.x before 1.466.12.1, when a slave is attached and anonymous read access is enabled, allows remote attackers to obtain the master cryptographic key via unknown vectors.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a9aff088f327278a8873aef47fa8f80d3c5932fd
+    repository: https://github.com/jenkinsci/jenkins.git
+  - id: c3d8e05a1b3d58b6c4dcff97394cb3a79608b4b2
+    repository: https://github.com/jenkinsci/jenkins.git
+  - id: 3dc13b957b14cec649036e8dd517f0f9cb21fb04
+    repository: https://github.com/jenkinsci/jenkins.git
+  - id: 4895eaafca468b7f0f1a3166b2fca7414f0d5da5
+    repository: https://github.com/jenkinsci/jenkins.git
+  - id: 94a8789b699132dd706021a6be1b78bc47f19602
+    repository: https://github.com/jenkinsci/jenkins.git

--- a/statements/CVE-2014-3498/statement.yaml
+++ b/statements/CVE-2014-3498/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2014-3498
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1335551
+  text: The user module in ansible before 1.6.6 allows remote authenticated users to execute arbitrary commands.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8ed6350e65c82292a631f08845dfaacffe7f07f5
+    repository: https://github.com/ansible/ansible

--- a/statements/CVE-2017-0906/statement.yaml
+++ b/statements/CVE-2017-0906/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-0906
+notes:
+- links: []
+  text: The Recurly Client Python Library before 2.0.5, 2.1.16, 2.2.22, 2.3.1, 2.4.5, 2.5.1, 2.6.2 is vulnerable to a Server-Side Request Forgery vulnerability in the "Resource.get" method that could result in compromise of API keys or other critical resources.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 049c74699ce93cf126feff06d632ea63fba36742
+    repository: https://github.com/recurly/recurly-client-python

--- a/statements/CVE-2017-7481/statement.yaml
+++ b/statements/CVE-2017-7481/statement.yaml
@@ -1,0 +1,21 @@
+vulnerability_id: CVE-2017-7481
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2017-7481
+  - https://snyk.io/vuln/SNYK-PYTHON-ANSIBLE-42165
+  text: Ansible before versions 2.3.1.0 and 2.4.0.0 fails to properly mark lookup-plugin results as unsafe. If an attacker could control the results of lookup() calls, they could inject Unicode strings to be parsed by the jinja2 templating system, resulting in code execution. By default, the jinja2 templating language is now marked as 'unsafe' and is not evaluated.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ed56f51f185a1ffd7ea57130d260098686fcc7c2
+    repository: https://github.com/ansible/ansible
+artifacts:
+- id: pkg:maven/ansible/ansible@2.8.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/ansible/ansible@2.7.12
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/ansible/ansible@2.3.0.0
+  reason: Reviewed manually
+  affected: true

--- a/statements/CVE-2018-12537/statement.yaml
+++ b/statements/CVE-2018-12537/statement.yaml
@@ -1,0 +1,79 @@
+vulnerability_id: CVE-2018-12537
+notes:
+- links: []
+  text: In Eclipse Vert.x version 3.0 to 3.5.1, the HttpServer response headers and HttpClient request headers do not filter carriage return and line feed characters from the header value. This allow unfiltered values to inject a new header in the client request or server response.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1bb6445226c39a95e7d07ce3caaf56828e8aab72
+    repository: https://github.com/eclipse/vert.x
+artifacts:
+- id: pkg:maven/io.vertx/vertx-core@3.2.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.vertx/vertx-core@3.4.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.vertx/vertx-core@3.5.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.vertx/vertx-core@3.6.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.6.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.8.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.8.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.8.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.8.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.0.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.vertx/vertx-core@3.5.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.vertx/vertx-core@3.5.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.3.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.vertx/vertx-core@3.5.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.5.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.6.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.6.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.7.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.7.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.8.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.8.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.9.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.vertx/vertx-core@3.9.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-16984/statement.yaml
+++ b/statements/CVE-2018-16984/statement.yaml
@@ -1,0 +1,50 @@
+vulnerability_id: CVE-2018-16984
+notes:
+- links:
+  - https://docs.djangoproject.com/en/2.1/releases/2.1.2/
+  text: An issue was discovered in Django 2.1 before 2.1.2, in which unprivileged users can read the password hashes of arbitrary accounts. The read-only password widget used by the Django Admin to display an obfuscated password hash was bypassed if a user has only the "view" permission (new in Django 2.1), resulting in display of the entire password hash to those users. This may result in a vulnerability for sites with legacy user accounts using insecure hashes.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bf39978a53f117ca02e9a0c78b76664a41a54745
+    repository: https://github.com/django/django
+artifacts:
+- id: pkg:maven/Django/Django@2.0.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Django/Django@2.2.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.0.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Django/Django@2.0.6
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Django/Django@2.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2019-1003012/statement.yaml
+++ b/statements/CVE-2019-1003012/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-1003012
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1003012
+  - https://jenkins.io/security/advisory/2019-01-28/#SECURITY-1201
+  text: A data modification vulnerability exists in Jenkins Blue Ocean Plugins 1.10.1 and earlier in blueocean-core-js/src/js/bundleStartup.js, blueocean-core-js/src/js/fetch.ts, blueocean-core-js/src/js/i18n/i18n.js, blueocean-core-js/src/js/urlconfig.js, blueocean-rest/src/main/java/io/jenkins/blueocean/rest/APICrumbExclusion.java, blueocean-web/src/main/java/io/jenkins/blueocean/BlueOceanUI.java, blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly that allows attackers to bypass all cross-site request forgery protection in Blue Ocean API.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1a03020b5a50c1e3f47d4b0902ec7fc78d3c86ce
+    repository: https://github.com/jenkinsci/blueocean-plugin

--- a/statements/CVE-2019-1003013/statement.yaml
+++ b/statements/CVE-2019-1003013/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-1003013
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1003013
+  - https://jenkins.io/security/advisory/2019-01-28/#SECURITY-1204
+  text: An cross-site scripting vulnerability exists in Jenkins Blue Ocean Plugins 1.10.1 and earlier in blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/Export.java, blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/ExportConfig.java, blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java, blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/UserStatePreloader.java, blueocean-web/src/main/resources/io/jenkins/blueocean/PageStatePreloadDecorator/header.jelly that allows attackers with permission to edit a user's description in Jenkins to have Blue Ocean render arbitrary HTML when using it as that user.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 62775e78532b756826bb237775b64a5052624b57
+    repository: https://github.com/jenkinsci/blueocean-plugin

--- a/statements/CVE-2019-12387/statement.yaml
+++ b/statements/CVE-2019-12387/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-12387
+notes:
+- links:
+  - https://labs.twistedmatrix.com/2019/06/twisted-1921-released.html
+  - https://twistedmatrix.com/pipermail/twisted-python/2019-June/032352.html
+  text: In Twisted before 19.2.1, twisted.web did not validate or sanitize URIs or HTTP methods, allowing an attacker to inject invalid characters such as CRLF.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6c61fc4503ae39ab8ecee52d10f10ee2c371d7e2
+    repository: https://github.com/twisted/twisted

--- a/statements/CVE-2019-18933/statement.yaml
+++ b/statements/CVE-2019-18933/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-18933
+notes:
+- links:
+  - https://blog.zulip.com/2019/11/21/zulip-2-0-7-security-release/
+  text: In Zulip Server versions from 1.7.0 to before 2.0.7, a bug in the new user signup process meant that users who registered their account using social authentication (e.g., GitHub or Google SSO) in an organization that also allows password authentication could have their personal API key stolen by an unprivileged attacker, allowing nearly full access to the user's account.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0c2cc41d2e40807baa5ee2c72987ebfb64ea2eb6
+    repository: https://github.com/zulip/zulip

--- a/statements/CVE-2019-19687/statement.yaml
+++ b/statements/CVE-2019-19687/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-19687
+notes:
+- links:
+  - https://bugs.launchpad.net/keystone/+bug/968696
+  text: OpenStack Keystone 15.0.0 and 16.0.0 is affected by Data Leakage in the list credentials API. Any user with a role on a project is able to list any credentials with the /v3/credentials API when enforce_scope is false. Users with a role on a project are able to view any other users' credentials, which could (for example) leak sign-on information for Time-based One Time Passwords (TOTP). Deployments with enforce_scope set to false are affected. (There will be a slight performance impact for the list credentials API once this issue is fixed.)
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 17c337dbdbfb9d548ad531c2ad0483c9bce5b98f
+    repository: https://github.com/openstack/keystone

--- a/statements/CVE-2019-3558/statement.yaml
+++ b/statements/CVE-2019-3558/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-3558
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3558
+  - https://www.facebook.com/security/advisories/cve-2019-3558
+  text: Python Facebook Thrift servers would not error upon receiving messages with containers of fields of unknown type. As a result, malicious clients could send short messages which would take a long time for the server to parse, potentially leading to denial of service. This issue affects Facebook Thrift prior to v2019.02.18.00.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c5d6e07588cd03061bc54d451a7fa6e84883d62b
+    repository: https://github.com/facebook/fbthrift

--- a/statements/CVE-2019-3559/statement.yaml
+++ b/statements/CVE-2019-3559/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-3559
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3559
+  - https://www.facebook.com/security/advisories/cve-2019-3559
+  text: Java Facebook Thrift servers would not error upon receiving messages with containers of fields of unknown type. As a result, malicious clients could send short messages which would take a long time for the server to parse, potentially leading to denial of service. This issue affects Facebook Thrift prior to v2019.02.18.00.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a56346ceacad28bf470017a6bda1d5518d0bd943
+    repository: https://github.com/facebook/fbthrift

--- a/statements/CVE-2020-10799/statement.yaml
+++ b/statements/CVE-2020-10799/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-10799
+notes:
+- links:
+  - https://github.com/deeplook/svglib/issues/229
+  text: The svglib package through 0.9.3 for Python allows XXE attacks via an svg2rlg call.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d6d08c4323a3656ee5ebe9a072a6e6237efde800
+    repository: https://github.com/deeplook/svglib

--- a/statements/CVE-2020-13654/statement.yaml
+++ b/statements/CVE-2020-13654/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-13654
+notes:
+- links:
+  - https://github.com/xwiki/xwiki-platform/pull/1315
+  text: XWiki Platform before 12.8 mishandles escaping in the property displayer.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 82c31ea56be4ac756140f082d216268e1dca6ac8
+    repository: https://github.com/xwiki/xwiki-platform

--- a/statements/CVE-2020-13757/statement.yaml
+++ b/statements/CVE-2020-13757/statement.yaml
@@ -1,0 +1,18 @@
+vulnerability_id: CVE-2020-13757
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13757
+  - https://github.com/sybrenstuvel/python-rsa/issues/146
+  text: Python-RSA before 4.1 ignores leading '\0' bytes during decryption of ciphertext. This could conceivably have a security-relevant impact, e.g., by helping an attacker to infer that an application uses Python-RSA, or if the length of accepted ciphertext affects application behavior (such as by causing excessive memory allocation).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 93af6f2f89a9bf28361e67716c4240e691520f30
+    repository: https://github.com/sybrenstuvel/python-rsa
+artifacts:
+- id: pkg:maven/rsa/rsa@4.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/rsa/rsa@4.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2020-25638/statement.yaml
+++ b/statements/CVE-2020-25638/statement.yaml
@@ -1,0 +1,242 @@
+vulnerability_id: CVE-2020-25638
+notes:
+- links:
+  - https://access.redhat.com/security/cve/cve-2020-25638
+  text: A flaw was found in hibernate-core in versions prior to and including 5.4.23.Final. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SQL comments of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks. The highest threat from this vulnerability is to data confidentiality and integrity.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 59fede7acaaa1579b561407aefa582311f7ebe78
+    repository: https://github.com/hibernate/hibernate-orm
+artifacts:
+- id: pkg:maven/org.hibernate/hibernate-core@5.0.11.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.0.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.0.12.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.11.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.1.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.0.4.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.0.7.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.2.21.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.8.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.1.2.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.12.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.6.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.10.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.1.10.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.6.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.14.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.16.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.10.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.17.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.0.5.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.2.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.1.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.6.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.1.3.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.13.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.5.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.7.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.5.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.1.16.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.1.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.3.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.2.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.2.1.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.10.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.3.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.4.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.11.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.12.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.6.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.2.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.13.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.8.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.14.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.10.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.15.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.11.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.12.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.16.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.14.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.15.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.17.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.5.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.16.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.17.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.18.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.13.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.20.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.19.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.21.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.18.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.1.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.1.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.22.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.1.14.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.2.13.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.23.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.24.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.hibernate/hibernate-core@5.3.20.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@4.3.7.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.25.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.hibernate/hibernate-core@5.4.26.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2020-26217/statement.yaml
+++ b/statements/CVE-2020-26217/statement.yaml
@@ -1,0 +1,17 @@
+vulnerability_id: CVE-2020-26217
+notes:
+- links:
+  - https://x-stream.github.io/CVE-2020-26217.html
+  text: XStream before version 1.4.14 is vulnerable to Remote Code Execution.The vulnerability may allow a remote attacker to run arbitrary shell commands only by manipulating the processed input stream. Only users who rely on blocklists are affected. Anyone using XStream's Security Framework allowlist is not affected. The linked advisory provides code workarounds for users who cannot upgrade. The issue is fixed in version 1.4.14.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0fec095d534126931c99fd38e9c6d41f5c685c1a
+    repository: https://github.com/x-stream/xstream
+artifacts:
+- id: pkg:maven/com.thoughtworks.xstream/xstream@1.4.13-java7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.thoughtworks.xstream/xstream@1.4.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true

--- a/statements/CVE-2020-26258/statement.yaml
+++ b/statements/CVE-2020-26258/statement.yaml
@@ -1,0 +1,15 @@
+vulnerability_id: CVE-2020-26258
+notes:
+- links:
+  - http://x-stream.github.io/CVE-2020-26258.html
+  - http://x-stream.github.io/changes.html
+  text: XStream is a Java library to serialize objects to XML and back again. In XStream before version 1.4.15, a Server-Side Forgery Request vulnerability can be activated when unmarshalling. The vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream. If you rely on XStream's default blacklist of the Security Framework, you will have to use at least version 1.4.15. The reported vulnerability does not exist if running Java 15 or higher. No user is affected who followed the recommendation to setup XStream's Security Framework with a whitelist! Anyone relying on XStream's default blacklist can immediately switch to a whilelist for the allowed types to avoid the vulnerability. Users of XStream 1.4.14 or below who still want to use XStream default blacklist can use a workaround described in more detailed in the referenced advisories.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6740c04b217aef02d44fba26402b35e0f6f493ce
+    repository: https://github.com/x-stream/xstream
+artifacts:
+- id: pkg:maven/com.thoughtworks.xstream/xstream@1.4.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true

--- a/statements/CVE-2020-26259/statement.yaml
+++ b/statements/CVE-2020-26259/statement.yaml
@@ -1,0 +1,15 @@
+vulnerability_id: CVE-2020-26259
+notes:
+- links:
+  - http://x-stream.github.io/CVE-2020-26259.html
+  - http://x-stream.github.io/changes.html
+  text: XStream is a Java library to serialize objects to XML and back again. In XStream before version 1.4.15, is vulnerable to an Arbitrary File Deletion on the local host when unmarshalling. The vulnerability may allow a remote attacker to delete arbitrary know files on the host as log as the executing process has sufficient rights only by manipulating the processed input stream. If you rely on XStream's default blacklist of the Security Framework, you will have to use at least version 1.4.15. The reported vulnerability does not exist running Java 15 or higher. No user is affected, who followed the recommendation to setup XStream's Security Framework with a whitelist! Anyone relying on XStream's default blacklist can immediately switch to a whilelist for the allowed types to avoid the vulnerability. Users of XStream 1.4.14 or below who still want to use XStream default blacklist can use a workaround described in more detailed in the referenced advisories.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0bcbf50126a62dfcd65f93a0da0c6d1ae92aa738
+    repository: https://github.com/x-stream/xstream
+artifacts:
+- id: pkg:maven/com.thoughtworks.xstream/xstream@1.4.15
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2021-21266/statement.yaml
+++ b/statements/CVE-2021-21266/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-21266
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21266
+  - https://github.com/openhab/openhab-addons/security/advisories/GHSA-r2hc-pmr7-4c9r
+  text: 'openHAB is a vendor and technology agnostic open source automation software for your home. In openHAB before versions 2.5.12 and 3.0.1 the XML external entity (XXE) attack allows attackers in the same network as the openHAB instance to retrieve internal information like the content of files from the file system. Responses to SSDP requests can be especially malicious. All add-ons that use SAX or JAXB parsing of externally received XML are potentially subject to this kind of attack. In openHAB, the following add-ons are potentially impacted: AvmFritz, BoseSoundtouch, DenonMarantz, DLinkSmarthome, Enigma2, FmiWeather, FSInternetRadio, Gce, Homematic, HPPrinter, IHC, Insteon, Onkyo, Roku, SamsungTV, Sonos, Roku, Tellstick, TR064, UPnPControl, Vitotronic, Wemo, YamahaReceiver and XPath Tranformation. The vulnerabilities have been fixed in versions 2.5.12 and 3.0.1 by a more strict configuration of the used XML parser.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 81935b0ab126e6d9aebd2f6c3fc67d82bb7e8b86
+    repository: https://github.com/openhab/openhab-addons

--- a/statements/CVE-2021-21290/statement.yaml
+++ b/statements/CVE-2021-21290/statement.yaml
@@ -1,0 +1,402 @@
+vulnerability_id: CVE-2021-21290
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21290
+  - https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2
+  text: Netty is an open-source, asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers & clients. In Netty before version 4.1.59.Final there is a vulnerability on Unix-like systems involving an insecure temp file. When netty's multipart decoders are used local information disclosure can occur via the local system temporary directory if temporary storing uploads on the disk is enabled. On unix-like systems, the temporary directory is shared between all user. As such, writing to this directory using APIs that do not explicitly set the file/directory permissions can lead to information disclosure. Of note, this does not impact modern MacOS Operating Systems. The method "File.createTempFile" on unix-like systems creates a random file, but, by default will create this file with the permissions "-rw-r--r--". Thus, if sensitive information is written to this file, other local users can read this information. This is the case in netty's "AbstractDiskHttpData" is vulnerable. This has been fixed in version 4.1.59.Final. As a workaround, one may specify your own "java.io.tmpdir" when you start the JVM or use "DefaultHttpDataFactory.setBaseDir(...)" to set the directory to something that is only readable by the current user.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c735357bf29d07856ad171c6611a2e1a0e0000ec
+    repository: https://github.com/netty/netty
+artifacts:
+- id: pkg:maven/io.netty/netty-handler@4.0.34.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.6.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.0.44.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.12.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.36.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.37.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.40.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.41.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.44.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.5.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.7.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.17.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.18.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.19.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.0.56.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.23.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.24.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.25.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.27.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.31.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.31.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.0.40.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.3.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.7.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.8.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.0.47.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.48.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.12.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.34.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.13.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.0.CR7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.52.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.0.52.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.16.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.5.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.33.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.35.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.21.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.20.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.0.CR3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.0.37.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.0.42.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.9.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.11.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.38.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.39.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.42.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.43.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.1.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.4.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.6.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.10.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.11.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.39.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.13.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.41.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.15.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.15.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.16.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.25.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.43.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.53.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.27.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.17.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.18.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.28.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.44.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.19.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.29.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.29.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.46.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.20.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.0.56.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.21.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.22.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.49.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.22.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.32.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.24.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.33.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.52.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.34.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.28.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.35.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.55.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.30.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.58.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.58.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.30.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.32.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.42.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.42.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.34.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.43.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.36.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.45.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.36.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.38.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.46.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.48.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.39.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.49.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.41.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.50.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.51.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.51.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.44.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.45.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.55.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.56.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.47.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.47.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.48.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.50.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.52.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-codec-http@4.1.53.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.53.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.53.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-codec-http@4.1.54.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-handler@4.1.54.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-all@4.1.54.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-codec-http@4.1.55.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-codec-http@4.1.56.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-codec-http@4.1.58.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/io.netty/netty-common@4.1.59.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.netty/netty-handler@4.1.59.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.netty/netty-codec-http@4.1.59.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/io.netty/netty-all@4.1.59.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false


### PR DESCRIPTION
## Background

While operating Eclipse Steady internally at SAP, the SAP Security Research team collected a dataset of approximately 1400 vulnerability statements of which a first dataset was published in 2019  as part of project KB (and described in [MSR 2019](https://github.com/SAP/project-kb/tree/main/MSR2019)).

Our goal is to disclose an additional batch of vulnerability statements from the SAP-internal dataset and to make them available to the community. To do so, we used Prospector to search for fix commits for the vulnerabilities corresponding to those internal data and we compared the findings of the tool with the fix commits we had identified through manual search. 

## Objective

With this PR we release **22** new statements for which the results found by Prospector (according to the criteria detailed below) matched exactly the fix commits that appeared in the statements of our private dataset, without considering twin commits as candidate fixes.

## Analysis Process

The process begins by executing Prospector to automatically identify fix commits for every vulnerability listed in our private dataset, using the vulnerability identifier and the URL of the vulnerable project's GitHub repository as input parameters. The internal dataset was used for both input parameters.

Upon completion of Prospector execution, an evaluation was performed examining all results from Prospector's findings, extracting candidate fix commits based on the rules that matched. 
The ranking system of Prospector evaluates each candidate fix commit based on predefined rules, assigning a relevance value to each. To ensure the highest level of confidence in identifying the commit as an effective patch, the statements released with this PR only contain fix commits that matched at least one high-relevance rule.

It is important to note that Prospector introduces the concept of _twin commit_. Twin commits can be categorized as an equivalent fix commit from a different, parallel branch. These twin commits refer to changes that are made on one branch and then applied to other branches that support different versions of the project.  
To better understand the impact of identifying twin commits when comparing the results gathered from Prospector with the internal dataset, we proceeded with two distinct evaluative measures. 
1. In the initial evaluation, the list of fix commits found by Prospector is composed of all high-confidence commits and their corresponding twins. The extracted commits were later used for the comparison with the internal dataset without distinguishing between twins and candidate fix commits. 
2. Later, we chose to replicate the commit extraction methodology, taking commits that matched at least a strong Prospector rule as before, but this time excluding all twin commits.

After having extracted all high-confidence commits from Prospector's findings and grouped them for each vulnerability, we compared the results with our internal dataset.  We decided to release as valid statements those that aligned with at least one of the following three validation criteria.

1. _Exact match:_ Prospector results matched exactly the fix commits that appeared in the internal dataset. 
2. _Exact match - twins excluded:_ Like the previous case but this time excluding twin commits as part of the set of fix commits.
3. _Strict subset:_  The commits of the internal dataset were a strict subset of Prospector results.

## Results

We discovered that 22 new statements matched the _Exact match - twins excluded_ validation criteria. For these additional 22 vulnerabilities, Prospector found the same commits of the internal dataset but also managed to identify twins of the matched fix commits that are not in the internal dataset.  By excluding the twin commits from the candidate fix commits found by Prospector, we were able to publish these supplementary statements. For the initial release of these new statements, we have decided to publish those containing the commits in the dataset exclusively, precluding any additional ones uncovered through Prospector.