### PR TITLE
Release of 133 statements (strict subset)

### DIFF
--- a/statements/CVE-2009-2625/statement.yaml
+++ b/statements/CVE-2009-2625/statement.yaml
@@ -1,0 +1,92 @@
+vulnerability_id: CVE-2009-2625
+notes:
+- links:
+  - https://issues.apache.org/jira/browse/XERCESJ-1412.
+  text: XMLScanner.java in Apache Xerces2 Java, as used in Sun Java Runtime Environment (JRE) in JDK and JRE 6 before Update 15 and JDK and JRE 5.0 before Update 20, and in other products, allows remote attackers to cause a denial of service (infinite loop and application hang) via malformed XML input, as demonstrated by the Codenomicon XML fuzzing framework.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "787352"
+    repository: http://svn.apache.org/repos/asf/xerces/java
+artifacts:
+- id: pkg:maven/xerces/xercesImpl@2.11.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/xerces/xercesImpl@2.8.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.4.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.0.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.0.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.9.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.9.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.6.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.8.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.3.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.3.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.7.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.7.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.2.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.2.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces@2.9.1_5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces@2.9.1_5
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.11.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/xerces/xercesImpl@2.10.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/xerces/xercesImpl@2.9.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.9.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.6.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/xerces/xercesImpl@2.12.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces@2.12.0_1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/com.rackspace.apache/xerces2-xsd11@2.11.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.avro/avro-tools@1.9.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.avro/avro-tools@1.9.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true

--- a/statements/CVE-2011-1088/statement.yaml
+++ b/statements/CVE-2011-1088/statement.yaml
@@ -1,0 +1,576 @@
+vulnerability_id: CVE-2011-1088
+notes:
+- links: []
+  text: Apache Tomcat 7.x before 7.0.10 does not follow ServletSecurity annotations, which allows remote attackers to bypass intended access restrictions via HTTP requests to a web application.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1076586"
+    repository: http://svn.apache.org/repos/asf/tomcat
+  - id: "1076587"
+    repository: http://svn.apache.org/repos/asf/tomcat
+  - id: "1077995"
+    repository: http://svn.apache.org/repos/asf/tomcat
+  - id: "1079752"
+    repository: http://svn.apache.org/repos/asf/tomcat
+  - id: "1079769"
+    repository: http://svn.apache.org/repos/asf/tomcat
+artifacts:
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.59
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.59
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.56
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.56
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.64
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.64
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.68
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.68
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.69
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.69
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.61
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.61
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.63
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.63
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.68
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.68
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.70
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.70
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.72
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.72
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.32
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.33
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.39
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.36
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.27
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.47
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.52
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.53
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.45
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.45
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.32
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.32
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.26
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.26
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.41
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.41
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.43
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.43
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.15
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.55
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.20
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.23
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.28
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.75
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.0.M3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.32
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.26
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.41
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.75
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/tomcat/catalina@5.5.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.35
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.35
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.44
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.44
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.48
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.48
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.15
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.0.M18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.26
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.0.M1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.79
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.53
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.0.M4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.57
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.53
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.33
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.30
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.69
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.36
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.37
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.41
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.47
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.46
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.23
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.47
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.82
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.77
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.27
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.27
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.78
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.44
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.78
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.15
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.0.45
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.20
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.20
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.81
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.21
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.23
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.82
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.24
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.24
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.20
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.19
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.19
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.20
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.21
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.22
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.22
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.29
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.29
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.26
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.30
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.30
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.30
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.30
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.31
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.33
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.34
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.34
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.35
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.36
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.36
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.37
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.38
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.21
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.38
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.39
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.40
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.24
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.41
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.24
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.26
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.27
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.27
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.31
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.33
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.35
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.37
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.40
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.41
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2011-1183/statement.yaml
+++ b/statements/CVE-2011-1183/statement.yaml
@@ -1,0 +1,67 @@
+vulnerability_id: CVE-2011-1183
+notes:
+- links: []
+  text: 'Apache Tomcat 7.0.11, when web.xml has no login configuration, does not follow security constraints, which allows remote attackers to bypass intended access restrictions via HTTP requests to a meta-data complete web application.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-1088 and CVE-2011-1419.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1087643"
+    repository: http://svn.apache.org/repos/asf/tomcat
+artifacts:
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.69
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.59
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.45
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.26
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.32
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.35
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.41
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.43
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.44
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.48
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.26
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/tomcat/catalina@5.5.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.53
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2011-1475/statement.yaml
+++ b/statements/CVE-2011-1475/statement.yaml
@@ -1,0 +1,174 @@
+vulnerability_id: CVE-2011-1475
+notes:
+- links: []
+  text: The HTTP BIO connector in Apache Tomcat 7.0.x before 7.0.12 does not properly handle HTTP pipelining, which allows remote attackers to read responses intended for other clients in opportunistic circumstances by examining the application data in HTTP packets, related to "a mix-up of responses for requests from different users."
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1086349"
+    repository: http://svn.apache.org/repos/asf/tomcat
+  - id: "1086352"
+    repository: http://svn.apache.org/repos/asf/tomcat
+artifacts:
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.69
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.69
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.59
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.59
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.45
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.45
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.26
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.35
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.41
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.43
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.44
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.48
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.26
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.32
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.32
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.35
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.41
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.43
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.44
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.48
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.68
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.68
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.72
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.64
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.0.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.53
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.0.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.47
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.0.36
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.0.32
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.0.33
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.0.39
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@7.0.75
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.0.41
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/tomcat/catalina@5.5.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/tomcat/tomcat-http@5.5.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.53
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/coyote@6.0.53
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.27
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.30
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.30
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.50
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-coyote@9.0.30
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2011-1582/statement.yaml
+++ b/statements/CVE-2011-1582/statement.yaml
@@ -1,0 +1,169 @@
+vulnerability_id: CVE-2011-1582
+notes:
+- links: []
+  text: 'Apache Tomcat 7.0.12 and 7.0.13 processes the first request to a servlet without following security constraints that have been configured through annotations, which allows remote attackers to bypass intended access restrictions via HTTP requests.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2011-1088, CVE-2011-1183, and CVE-2011-1419.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1100832"
+    repository: http://svn.apache.org/repos/asf/tomcat
+artifacts:
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.69
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.69
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.59
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.56
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.61
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.63
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.64
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.68
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.68
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.70
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.72
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.27
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.47
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.52
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.53
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.45
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.26
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.32
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.35
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.41
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.43
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.44
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.48
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.75
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.55
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.57
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.53
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.69
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.47
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.26
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.75
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/tomcat/catalina@5.5.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.0.M18
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.12
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.77
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.15
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/catalina@6.0.53
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.78
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.44
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.78
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@8.5.15
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.79
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.81
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@7.0.82
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@7.0.82
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.30
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.30
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2011-4905/statement.yaml
+++ b/statements/CVE-2011-4905/statement.yaml
@@ -1,0 +1,127 @@
+vulnerability_id: CVE-2011-4905
+notes:
+- links: []
+  text: Apache ActiveMQ before 5.6.0 allows remote attackers to cause a denial of service (file-descriptor exhaustion and broker crash or hang) by sending many openwire failover:tcp:// connection requests.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1209700"
+    repository: http://svn.apache.org/repos/asf/activemq
+artifacts:
+- id: pkg:maven/org.apache.activemq/activemq-client@5.10.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.10.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.8.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.10.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.12.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.13.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.13.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.14.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.8.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.10.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.11.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.12.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.13.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.13.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.14.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.13.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.14.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.14.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.14.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.15.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.15.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-all@5.13.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-all@5.9.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-all@5.11.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-all@5.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-all@5.15.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-all@5.4.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-all@5.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-client@5.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-broker@5.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-core@5.5.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-core@5.5.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-core@5.7.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-core@5.5.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-core@5.5.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-unit-tests@5.15.2
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2012-5633/statement.yaml
+++ b/statements/CVE-2012-5633/statement.yaml
@@ -1,0 +1,611 @@
+vulnerability_id: CVE-2012-5633
+notes:
+- links: []
+  text: The URIMappingInterceptor in Apache CXF before 2.5.8, 2.6.x before 2.6.5, and 2.7.x before 2.7.2, when using the WSS4JInInterceptor, bypasses WS-Security processing, which allows remote attackers to obtain access to SOAP services via an HTTP GET request.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1409324"
+    repository: http://svn.apache.org/repos/asf/cxf
+  - id: "1409326"
+    repository: http://svn.apache.org/repos/asf/cxf
+  - id: "1420698"
+    repository: http://svn.apache.org/repos/asf/cxf
+artifacts:
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@3.1.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.6.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.6.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.3.8
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.3.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.3.8
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.3.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.3.8
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.3.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.17
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.18
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@3.0.12
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.3.8
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.7.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.7.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@3.1.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.7.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.7.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.7.18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@3.0.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@3.0.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@2.0.9
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-api@2.0.9
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-api@2.2.10
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-api@2.3.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.17
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.7.18
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.0.9
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.2.10
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.2.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.3.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.3.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.6.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.6.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.17
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-core@2.7.18
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.0.9
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.2.10
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.2.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.3.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.3.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.13
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.14
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.17
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.7.18
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.12
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@3.1.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@3.1.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@3.1.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-api@2.6.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@2.6.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.3.10
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.3.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.5.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.7.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.7.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.7.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.7.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.7.18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle-jaxrs@2.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.0.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.tomee.patch/cxf-rt-bindings-xml@2.6.17-TomEE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.tomee.patch/cxf-api@2.6.17-TomEE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle@2.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.15
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle@2.7.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle@2.7.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@3.2.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.1.18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-soap@3.3.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@3.3.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.3.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-bindings-xml@3.2.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2013-0239/statement.yaml
+++ b/statements/CVE-2013-0239/statement.yaml
@@ -1,0 +1,40 @@
+vulnerability_id: CVE-2013-0239
+notes:
+- links: []
+  text: Apache CXF before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3, when the plaintext UsernameToken WS-SecurityPolicy is enabled, allows remote attackers to bypass authentication via a security header of a SOAP request containing a UsernameToken element that lacks a password child element.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1438424"
+    repository: http://svn.apache.org/repos/asf/cxf
+artifacts:
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.6.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.17
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle@2.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.3.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.16
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle@2.7.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@2.7.18
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-rt-ws-security@3.3.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.apache.cxf/cxf-bundle@2.7.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2013-1445/statement.yaml
+++ b/statements/CVE-2013-1445/statement.yaml
@@ -1,0 +1,42 @@
+vulnerability_id: CVE-2013-1445
+notes:
+- links:
+  - http://www.openwall.com/lists/oss-security/2013/10/17/3
+  - https://www.cvedetails.com/cve/CVE-2013-1445/
+  text: The Crypto.Random.atfork function in PyCrypto before 2.6.1 does not properly reseed the pseudo-random number generator (PRNG) before allowing a child process to access it, which makes it easier for context-dependent attackers to obtain sensitive information by leveraging a race condition in which a child process is created and accesses the PRNG within the same rate-limit period as another process.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 19dcf7b15d61b7dc1a125a367151de40df6ef175
+    repository: https://github.com/dlitz/pycrypto
+artifacts:
+- id: pkg:maven/pycrypto/pycrypto@2.6.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycrypto/pycrypto@2.6.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.11
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.7.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.8.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.8.2
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2013-7330/statement.yaml
+++ b/statements/CVE-2013-7330/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2013-7330
+notes:
+- links: []
+  text: Jenkins before 1.502 allows remote authenticated users to configure an otherwise restricted project via vectors related to post-build actions.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 36342d71e29e0620f803a7470ce96c61761648d8
+    repository: https://github.com/jenkinsci/jenkins.git

--- a/statements/CVE-2014-0012/statement.yaml
+++ b/statements/CVE-2014-0012/statement.yaml
@@ -1,0 +1,42 @@
+vulnerability_id: CVE-2014-0012
+notes:
+- links:
+  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734747
+  - https://www.cvedetails.com/cve/CVE-2014-0012/
+  text: 'FileSystemBytecodeCache in Jinja2 2.7.2 does not properly create temporary directories, which allows local users to gain privileges by pre-creating a temporary directory with a user''s uid.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-1402.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: acb672b6a179567632e032f547582f30fa2f4aa7
+    repository: https://github.com/pallets/jinja
+artifacts:
+- id: pkg:maven/Jinja2/Jinja2@2.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.7.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.7.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.7.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.9.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.9.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.10.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.10.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.11.0
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2014-1858/statement.yaml
+++ b/statements/CVE-2014-1858/statement.yaml
@@ -1,0 +1,389 @@
+vulnerability_id: CVE-2014-1858
+notes:
+- links: []
+  text: __init__.py in f2py in NumPy before 1.8.1 allows local users to write to arbitrary files via a symlink attack on a temporary file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0bb46c1448b0d3f5453d5182a17ea7ac5854ee15
+    repository: https://github.com/numpy/numpy
+- id: 1.8.x
+  commits:
+  - id: 961c43da78bf97ce63183b27c338db7ea77bed8
+    repository: https://github.com/numpy/numpy
+artifacts:
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2014-1932/statement.yaml
+++ b/statements/CVE-2014-1932/statement.yaml
@@ -1,0 +1,46 @@
+vulnerability_id: CVE-2014-1932
+notes:
+- links: []
+  text: The (1) load_djpeg function in JpegImagePlugin.py, (2) Ghostscript function in EpsImagePlugin.py, (3) load function in IptcImagePlugin.py, and (4) _copy function in Image.py in Python Image Library (PIL) 1.1.7 and earlier and Pillow before 2.3.1 do not properly create temporary files, which allow local users to overwrite arbitrary files and obtain sensitive information via a symlink attack on the temporary file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4e9f367dfd3f04c8f5d23f7f759ec12782e10ee7
+    repository: https://github.com/python-pillow/Pillow
+artifacts:
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@4.2.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@2.9.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@3.1.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@5.3.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@4.2.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@5.2.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@5.3.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Pillow/Pillow@5.3.0
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2014-1938/statement.yaml
+++ b/statements/CVE-2014-1938/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2014-1938
+notes:
+- links:
+  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737627
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1938
+  - https://github.com/alex/rply/issues/42
+  text: python-rply before 0.7.4 insecurely creates temporary files.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 76d268a38c627bf4aebebcd064f5b6d380eb8b20
+    repository: https://github.com/alex/rply

--- a/statements/CVE-2014-3490/statement.yaml
+++ b/statements/CVE-2014-3490/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2014-3490
+notes:
+- links: []
+  text: 'RESTEasy 2.3.1 before 2.3.8.SP2 and 3.x before 3.0.9, as used in Red Hat JBoss Enterprise Application Platform (EAP) 6.3.0, does not disable external entities when the resteasy.document.expand.entity.references parameter is set to false, which allows remote attackers to read arbitrary files and have other unspecified impact via unspecified vectors, related to an XML External Entity (XXE) issue.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-0818.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9b7d0f574cafdcf3bea5428f3145ab4908fc6d83
+    repository: https://github.com/ronsigal/Resteasy.git

--- a/statements/CVE-2014-6633/statement.yaml
+++ b/statements/CVE-2014-6633/statement.yaml
@@ -1,0 +1,36 @@
+vulnerability_id: CVE-2014-6633
+notes:
+- links:
+  - http://www.tryton.org/posts/security-release-for-issue4155.html
+  text: The safe_eval function in trytond in Tryton before 2.4.15, 2.6.x before 2.6.14, 2.8.x before 2.8.11, 3.0.x before 3.0.7, and 3.2.x before 3.2.3 allows remote authenticated users to execute arbitrary commands via shell metacharacters in (1) the collection.domain in the webdav module or (2) the formula field in the price_list module.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 13b9fce7296a6301343ab67fab2f1a1af61e4bb0
+    repository: https://github.com/tryton/trytond
+  - id: 397765e3e2b2a3b6fbba886396bf9aa047e74a99
+    repository: https://github.com/tryton/trytond
+- id: "2.8"
+  commits:
+  - id: 37cd017ce2aaa346582fb53fd418c27449e0029
+    repository: https://github.com/tryton/trytond
+  - id: 5781ddbc5a4383a937f9d1c56344b81933f8697
+    repository: https://github.com/tryton/trytond
+- id: "3.2"
+  commits:
+  - id: 56a8b67b94ce0d5426af5ec7e5665f9c74afb73
+    repository: https://github.com/tryton/trytond
+  - id: 92838f6da258ad9f7344c5eb1d10951decc115a
+    repository: https://github.com/tryton/trytond
+- id: "2.4"
+  commits:
+  - id: 6e7fc491128bfb81f6441c018361c83787a6500
+    repository: https://github.com/tryton/trytond
+  - id: dd0dc77c928e012497cf7a231858b5794a7b0b4
+    repository: https://github.com/tryton/trytond
+- id: "2.6"
+  commits:
+  - id: 755fec183cf17816c0ded2b8e5cda89e527744b
+    repository: https://github.com/tryton/trytond
+  - id: dc0c3cd5176819efdbf0d22376c8ad2f298e14a
+    repository: https://github.com/tryton/trytond

--- a/statements/CVE-2014-8125/statement.yaml
+++ b/statements/CVE-2014-8125/statement.yaml
@@ -1,0 +1,31 @@
+vulnerability_id: CVE-2014-8125
+notes:
+- links: []
+  text: XML external entity (XXE) vulnerability in Drools and jBPM before 6.2.0 allows remote attackers to read arbitrary files or possibly have other unspecified impact via a crafted BPMN2 file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c48464c3b246e6ef0d4cd0dbf67e83ccd532c6d3
+    repository: https://github.com/droolsjbpm/drools.git
+artifacts:
+- id: pkg:maven/org.drools/drools-core@6.5.0.Beta1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.drools/drools-core@6.5.0.Beta1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.drools/drools-core@6.4.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.drools/drools-core@6.5.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.drools/drools-core@6.3.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.drools/drools-core@5.5.0.Final
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.drools/drools-core@7.0.0.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2014-8650/statement.yaml
+++ b/statements/CVE-2014-8650/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2014-8650
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-8650
+  - https://github.com/requests/requests-kerberos/issues/35
+  - https://github.com/requests/requests-kerberos/pull/36
+  text: python-requests-Kerberos through 0.5 does not handle mutual authentication
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 208bebb7008796a07be0204d9b5beaa55d2373ae
+    repository: https://github.com/requests/requests-kerberos

--- a/statements/CVE-2015-1326/statement.yaml
+++ b/statements/CVE-2015-1326/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2015-1326
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-1326
+  text: python-dbusmock before version 0.15.1 AddTemplate() D-Bus method call or DBusTestCase.spawn_server_template() method could be tricked into executing malicious code if an attacker supplies a .pyc file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4e7d0df9093
+    repository: https://github.com/martinpitt/python-dbusmock

--- a/statements/CVE-2015-2296/statement.yaml
+++ b/statements/CVE-2015-2296/statement.yaml
@@ -1,0 +1,46 @@
+vulnerability_id: CVE-2015-2296
+notes:
+- links: []
+  text: The resolve_redirects function in sessions.py in requests 2.1.0 through 2.5.3 allows remote attackers to conduct session fixation attacks via a cookie without a host value in a redirect.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3bd8afbff29e50b38f889b2f688785a669b9aafc
+    repository: https://github.com/requests/requests
+artifacts:
+- id: pkg:maven/requests/requests@2.18.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.9.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.11.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.14.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.18.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.18.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.19.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.20.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.20.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.21.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.22.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.23.0
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2015-5159/statement.yaml
+++ b/statements/CVE-2015-5159/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-5159
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1245200
+  - https://snyk.io/vuln/SNYK-PYTHON-KDCPROXY-72557
+  text: python-kdcproxy before 0.3.2 allows remote attackers to cause a denial of service via a large POST request.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f274aa6787cb8b3ec1cc12c440a56665b7231882
+    repository: https://github.com/latchset/kdcproxy

--- a/statements/CVE-2015-5607/statement.yaml
+++ b/statements/CVE-2015-5607/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2015-5607
+notes:
+- links:
+  - https://www.cvedetails.com/cve/CVE-2015-5607/
+  text: Cross-site request forgery in the REST API in IPython 2 and 3.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1415a9710407e7c14900531813c15ba6165f0816
+    repository: https://github.com/ipython/ipython

--- a/statements/CVE-2015-8034/statement.yaml
+++ b/statements/CVE-2015-8034/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-8034
+notes:
+- links:
+  - https://docs.saltstack.com/en/latest/topics/releases/2015.8.3.html
+  - https://github.com/saltstack/salt/issues/28455
+  - https://www.cvedetails.com/cve/CVE-2015-8034/
+  text: The state.sls function in Salt before 2015.8.3 uses weak permissions on the cache data, which allows local users to obtain sensitive information by reading the file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 097838ec0c52b1e96f7f761e5fb3cd7e79808741
+    repository: https://github.com/saltstack/salt

--- a/statements/CVE-2016-10127/statement.yaml
+++ b/statements/CVE-2016-10127/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2016-10127
+notes:
+- links: []
+  text: PySAML2 allows remote attackers to conduct XML external entity (XXE) attacks via a crafted SAML XML request or response.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6e09a25d9b4b7aa7a506853210a9a14100b8bc9b
+    repository: https://github.com/rohe/pysaml2

--- a/statements/CVE-2016-10149/statement.yaml
+++ b/statements/CVE-2016-10149/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2016-10149
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10149
+  text: XML External Entity (XXE) vulnerability in PySAML2 4.4.0 and earlier allows remote attackers to read arbitrary files via a crafted SAML XML request or response.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6e09a25d9b4b7aa7a506853210a9a14100b8bc9b
+    repository: https://github.com/rohe/pysaml2

--- a/statements/CVE-2016-10516/statement.yaml
+++ b/statements/CVE-2016-10516/statement.yaml
@@ -1,0 +1,50 @@
+vulnerability_id: CVE-2016-10516
+notes:
+- links:
+  - https://github.com/pallets/werkzeug/pull/1001
+  text: Cross-site scripting (XSS) vulnerability in the render_full function in debug/tbtools.py in the debugger in Pallets Werkzeug before 0.11.11 (as used in Pallets Flask and other products) allows remote attackers to inject arbitrary web script or HTML via a field that contains an exception message.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1034edc7f901dd645ec6e462754111b39002bd65
+    repository: https://github.com/pallets/werkzeug
+artifacts:
+- id: pkg:maven/Werkzeug/Werkzeug@0.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.11.10
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Werkzeug/Werkzeug@0.12.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@1.0.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.16.1
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2016-10745/statement.yaml
+++ b/statements/CVE-2016-10745/statement.yaml
@@ -1,0 +1,44 @@
+vulnerability_id: CVE-2016-10745
+notes:
+- links:
+  - https://nvd.nist.gov/vuln/detail/CVE-2016-10745
+  text: In Pallets Jinja before 2.8.1, str.format allows a sandbox escape.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9b53045c34e61013dc8f09b7e52a555fa16bed16
+    repository: https://github.com/pallets/jinja
+artifacts:
+- id: pkg:maven/Jinja2/Jinja2@2.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.7.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.7.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.7.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.9.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.9.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.10.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.11.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.11.1
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2016-6581/statement.yaml
+++ b/statements/CVE-2016-6581/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-6581
+notes:
+- links:
+  - https://github.com/python-hyper/hpack/pull/56
+  - https://python-hyper.org/hpack/en/latest/security/CVE-2016-6581.html
+  text: A HTTP/2 implementation built using any version of the Python HPACK library between v1.0.0 and v2.2.0 could be targeted for a denial of service attack, specifically a so-called "HPACK Bomb" attack. This attack occurs when an attacker inserts a header field that is exactly the size of the HPACK dynamic header table into the dynamic header table. The attacker can then send a header block that is simply repeated requests to expand that field in the dynamic table. This can lead to a gigantic compression ratio of 4,096 or better, meaning that 16kB of data can decompress to 64MB of data on the target machine.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4529c1632a356cc1ab6a7fdddccd2de60a21e366
+    repository: https://github.com/python-hyper/hpack

--- a/statements/CVE-2016-6801/statement.yaml
+++ b/statements/CVE-2016-6801/statement.yaml
@@ -1,0 +1,46 @@
+vulnerability_id: CVE-2016-6801
+notes:
+- links: []
+  text: Cross-site request forgery (CSRF) vulnerability in the CSRF content-type check in Jackrabbit-Webdav in Apache Jackrabbit 2.4.x before 2.4.6, 2.6.x before 2.6.6, 2.8.x before 2.8.3, 2.10.x before 2.10.4, 2.12.x before 2.12.4, and 2.13.x before 2.13.3 allows remote attackers to hijack the authentication of unspecified victims for requests that create a resource via an HTTP POST request with a (1) missing or (2) crafted Content-Type header.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: "1758600"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1758771"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1761912"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1761915"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1761916"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1761911"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1761913"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1758597"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1758609"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1758761"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1758764"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1758791"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+  - id: "1761909"
+    repository: http://svn.apache.org/repos/asf/jackrabbit
+artifacts:
+- id: pkg:maven/org.apache.jackrabbit/jackrabbit-webdav@2.5.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.jackrabbit/jackrabbit-webdav@1.5.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.jackrabbit/jackrabbit-webdav@2.17.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.jackrabbit/jackrabbit-webdav@2.21.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2016-8640/statement.yaml
+++ b/statements/CVE-2016-8640/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-8640
+notes:
+- links:
+  - http://seclists.org/oss-sec/2016/q4/406
+  - https://github.com/geopython/pycsw/pull/474
+  text: A SQL injection vulnerability in pycsw all versions before 2.0.2, 1.10.5 and 1.8.6 that leads to read and extract of any data from any table in the pycsw database that the database user has access to. Also on PostgreSQL (at least) it is possible to perform updates/inserts/deletes and database modifications to any table the database user has access to.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2565ab332d3ccae328591ea9054d0387a90f2e86
+    repository: https://github.com/geopython/pycsw

--- a/statements/CVE-2016-9243/statement.yaml
+++ b/statements/CVE-2016-9243/statement.yaml
@@ -1,0 +1,179 @@
+vulnerability_id: CVE-2016-9243
+notes:
+- links:
+  - https://www.cvedetails.com/vulnerability-list/vendor_id-16276/product_id-36638/year-2017/Cryptography.io-Cryptography.html
+  text: HKDF in cryptography before 1.5.2 returns an empty byte-string if used with a length less than algorithm.digest_size.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b924696b2e8731f39696584d12cceeb3aeb2d874
+    repository: https://github.com/pyca/cryptography
+artifacts:
+- id: pkg:maven/cryptography/cryptography@1.2.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.0.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/cryptography/cryptography@1.0.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/cryptography/cryptography@1.3.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/cryptography/cryptography@1.3.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/cryptography/cryptography@1.7.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.7.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.3.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.3.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.3.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.3.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.6.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.6.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.2.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/cryptography/cryptography@1.7.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.7.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.6.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.6.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.9.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.9.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2016-9909/statement.yaml
+++ b/statements/CVE-2016-9909/statement.yaml
@@ -1,0 +1,29 @@
+vulnerability_id: CVE-2016-9909
+notes:
+- links:
+  - https://www.cvedetails.com/cve/CVE-2016-9909/
+  text: The serializer in html5lib before 0.99999999 might allow remote attackers to conduct cross-site scripting (XSS) attacks by leveraging mishandling of the < (less than) character in attribute values.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9b8d8eb5afbc066b7fac9390f5ec75e5e8a7cab7
+    repository: https://github.com/html5lib/html5lib-python
+artifacts:
+- id: pkg:maven/html5lib/html5lib@0.9999999
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/html5lib/html5lib@1.0b8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/html5lib/html5lib@0.99999999
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/html5lib/html5lib@1.0b9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/html5lib/html5lib@0.999
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/html5lib/html5lib@1.0.1
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2016-9910/statement.yaml
+++ b/statements/CVE-2016-9910/statement.yaml
@@ -1,0 +1,28 @@
+vulnerability_id: CVE-2016-9910
+notes:
+- links: []
+  text: The serializer in html5lib before 0.99999999 might allow remote attackers to conduct cross-site scripting (XSS) attacks by leveraging mishandling of special characters in attribute values, a different vulnerability than CVE-2016-9909.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9b8d8eb5afbc066b7fac9390f5ec75e5e8a7cab7
+    repository: https://github.com/html5lib/html5lib-python
+artifacts:
+- id: pkg:maven/html5lib/html5lib@0.9999999
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/html5lib/html5lib@0.999
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/html5lib/html5lib@1.0b8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/html5lib/html5lib@0.99999999
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/html5lib/html5lib@1.0.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/html5lib/html5lib@1.0b9
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2017-0359/statement.yaml
+++ b/statements/CVE-2017-0359/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-0359
+notes:
+- links:
+  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=854723
+  text: diffoscope before 77 writes to arbitrary locations on disk based on the contents of an untrusted archive.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 632a40828a54b399787c25e7fa243f732aef7e05
+    repository: https://salsa.debian.org/reproducible-builds/diffoscope.git

--- a/statements/CVE-2017-1000433/statement.yaml
+++ b/statements/CVE-2017-1000433/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-1000433
+notes:
+- links: []
+  text: pysaml2 version 4.4.0 and older accept any password when run with python optimizations enabled. This allows attackers to log in as any user without knowing their password.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6312a41e037954850867f29d329e5007df1424a5
+    repository: https://github.com/rohe/pysaml2

--- a/statements/CVE-2017-12791/statement.yaml
+++ b/statements/CVE-2017-12791/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-12791
+notes:
+- links: []
+  text: Directory traversal vulnerability in minion id validation in SaltStack Salt before 2016.11.7 and 2017.7.x before 2017.7.1 allows remote minions with incorrect credentials to authenticate to a master via a crafted minion ID.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6366e05d0d70bd709cc4233c3faf32a759d0173a
+    repository: https://github.com/saltstack/salt

--- a/statements/CVE-2017-12852/statement.yaml
+++ b/statements/CVE-2017-12852/statement.yaml
@@ -1,0 +1,246 @@
+vulnerability_id: CVE-2017-12852
+notes:
+- links: []
+  text: The numpy.pad function in Numpy 1.13.1 and older versions is missing input validation. An empty list or ndarray will stick into an infinite loop, which can allow attackers to cause a DoS attack.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 01718a9feb7f949b091e4f95320c1a60116e77a5
+    repository: https://github.com/numpy/numpy
+  - id: 11593aa176d491beb0cc5ffcc393956a5435a2bf
+    repository: https://github.com/numpy/numpy
+- id: 1.13.x
+  commits:
+  - id: ba443cedf6e0194ab85f362f7d7ca89dca432e7
+    repository: https://github.com/numpy/numpy
+  - id: d57ada7c0c9900bfe8dfa139fa6419c4307ecb2
+    repository: https://github.com/numpy/numpy
+artifacts:
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.13.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.14.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.16.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.17.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/numpy/numpy@1.18.1
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2017-16616/statement.yaml
+++ b/statements/CVE-2017-16616/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-16616
+notes:
+- links: []
+  text: An exploitable vulnerability exists in the YAML parsing functionality in the YAMLParser method in Interfaces.py in PyAnyAPI before 0.6.1. A YAML parser can execute arbitrary Python commands resulting in command execution because load is used where safe_load should have been used. An attacker can insert Python into loaded YAML to trigger this vulnerability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 810db626c18ebc261d5f4299d0f0eac38d5eb3cf
+    repository: https://github.com/Stranger6667/pyanyapi

--- a/statements/CVE-2017-16763/statement.yaml
+++ b/statements/CVE-2017-16763/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-16763
+notes:
+- links: []
+  text: An exploitable vulnerability exists in the YAML parsing functionality in config.py in Confire 0.2.0. Due to the user-specific configuration being loaded from "~/.confire.yaml" using the yaml.load function, a YAML parser can execute arbitrary Python commands resulting in command execution. An attacker can insert Python into loaded YAML to trigger this vulnerability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8cc86a5ec2327e070f1d576d61bbaadf861597ea
+    repository: https://github.com/bbengfort/confire

--- a/statements/CVE-2017-18638/statement.yaml
+++ b/statements/CVE-2017-18638/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-18638
+notes:
+- links:
+  - https://blog.orange.tw/2017/07/how-i-chained-4-vulnerabilities-on.html#second-bug-internal-graphite-ssrf
+  - https://github.com/graphite-project/graphite-web/issues/2008
+  text: send_email in graphite-web/webapp/graphite/composer/views.py in Graphite through 1.1.5 is vulnerable to SSRF. The vulnerable SSRF endpoint can be used by an attacker to have the Graphite web server request any resource. The response to this SSRF request is encoded into an image file and then sent to an e-mail address that can be supplied by the attacker. Thus, an attacker can exfiltrate any information.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 71726a0e41a5263f49b973a7b856505a5b931c1f
+    repository: https://github.com/graphite-project/graphite-web

--- a/statements/CVE-2017-4995/statement.yaml
+++ b/statements/CVE-2017-4995/statement.yaml
@@ -1,0 +1,288 @@
+vulnerability_id: CVE-2017-4995
+notes:
+- links:
+  - https://pivotal.io/security/cve-2017-4995
+  text: 'An issue was discovered in Pivotal Spring Security 4.2.0.RELEASE through 4.2.2.RELEASE, and Spring Security 5.0.0.M1. When configured to enable default typing, Jackson contained a deserialization vulnerability that could lead to arbitrary code execution. Jackson fixed this vulnerability by blacklisting known "deserialization gadgets." Spring Security configures Jackson with global default typing enabled, which means that (through the previous exploit) arbitrary code could be executed if all of the following is true: (1) Spring Security''s Jackson support is being leveraged by invoking SecurityJackson2Modules.getModules(ClassLoader) or SecurityJackson2Modules.enableDefaultTyping(ObjectMapper); (2) Jackson is used to deserialize data that is not trusted (Spring Security does not perform deserialization using Jackson, so this is an explicit choice of the user); and (3) there is an unknown (Jackson is not blacklisting it already) "deserialization gadget" that allows code execution present on the classpath. Jackson provides a blacklisting approach to protecting against this type of attack, but Spring Security should be proactive against blocking unknown "deserialization gadgets" when Spring Security enables default typing.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5dee8534cd1b92952d10cc56335b5d5856f48f3b
+    repository: https://github.com/spring-projects/spring-security
+- id: 4.2.x
+  commits:
+  - id: 947d11f433b78294942cb5ea56e8aa5c3a0ca43
+    repository: https://github.com/spring-projects/spring-security
+artifacts:
+- id: pkg:maven/org.springframework.security/spring-security-core@4.1.2.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.6.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.1.3.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.1.1.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.8.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.5.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.1.4.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.4.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.1.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.springframework.security/spring-security-core@4.0.4.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.2.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.springframework.security/spring-security-core@4.0.3.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.3.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.0.7.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.1.1.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.1.2.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.0.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.3.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.7.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.9.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@3.2.10.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.0.0.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.0.2.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.1.0.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.0.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.4.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.4.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.1.5.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.3.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.5.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.4.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.6.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.5.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.6.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.7.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.7.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.8.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.8.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.8.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.0.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.9.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.9.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.1.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.10.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.10.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.2.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.11.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.11.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.3.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.4.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.12.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.12.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.12.RELEASE
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.5.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-core@4.2.4.RELEASE_1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.13.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.13.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.6.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.0.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.7.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.1.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.2.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.14.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.8.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.3.0.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.15.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.15.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.9.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.3.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.3.1.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.10.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.4.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.16.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.16.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.3.2.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.11.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.5.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.3.3.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.17.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.18.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.12.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.6.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.3.4.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.19.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.3.5.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.1.13.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.7.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.3.6.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.2.8.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@4.2.20.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.springframework.security/spring-security-core@5.0.19.RELEASE
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2017-7233/statement.yaml
+++ b/statements/CVE-2017-7233/statement.yaml
@@ -1,0 +1,56 @@
+vulnerability_id: CVE-2017-7233
+notes:
+- links: []
+  text: Django 1.10 before 1.10.7, 1.9 before 1.9.13, and 1.8 before 1.8.18 relies on user input in some cases to redirect the user to an "on success" URL. The security check for these redirects (namely ``django.utils.http.is_safe_url()``) considered some numeric URLs "safe" when they shouldn't be, aka an open redirect vulnerability. Also, if a developer relies on ``is_safe_url()`` to provide safe redirect targets and puts such a URL into a link, they could suffer from an XSS attack.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5ea48a70afac5e5684b504f09286e7defdd1a81a
+    repository: https://github.com/django/django
+- id: "1.8"
+  commits:
+  - id: 8339277518c7d8ec280070a780915304654e3b6
+    repository: https://github.com/django/django
+- id: "1.11"
+  commits:
+  - id: 97e77b7bc14eafda704a01881cb2a3dc164947b
+    repository: https://github.com/django/django
+- id: "1.10"
+  commits:
+  - id: f824655bc2c50b19d2f202d7640785caabc8278
+    repository: https://github.com/django/django
+- id: "1.9"
+  commits:
+  - id: 254326cb3682389f55f886804d2c43f7b9f23e4
+    repository: https://github.com/django/django
+artifacts:
+- id: pkg:maven/Django/Django@2.0.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.0.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.0.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.0.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.0.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.0.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2017-7893/statement.yaml
+++ b/statements/CVE-2017-7893/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2017-7893
+notes:
+- links:
+  - https://docs.saltstack.com/en/2017.7/topics/releases/2016.3.6.html
+  - https://github.com/saltstack/salt/issues/48939
+  - https://github.com/saltstack/salt/pull/39855
+  - https://www.cvedetails.com/cve/CVE-2017-7893/
+  text: In SaltStack Salt before 2016.3.6, compromised salt-minions can impersonate the salt-master.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0a0f46fb1478be5eb2f90882a90390cb35ec43cb
+    repository: https://github.com/saltstack/salt

--- a/statements/CVE-2017-8109/statement.yaml
+++ b/statements/CVE-2017-8109/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-8109
+notes:
+- links:
+  - https://github.com/saltstack/salt/issues/40075
+  - https://snyk.io/vuln/SNYK-PYTHON-SALT-42127
+  text: The salt-ssh minion code in SaltStack Salt 2016.11 before 2016.11.4 copied over configuration from the Salt Master without adjusting permissions, which might leak credentials to local attackers on configured minions (clients).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6e34c2b5e5e849302af7ccd00509929c3809c658
+    repository: https://github.com/saltstack/salt

--- a/statements/CVE-2018-1000159/statement.yaml
+++ b/statements/CVE-2018-1000159/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-1000159
+notes:
+- links:
+  - https://github.com/tomato42/tlslite-ng/pull/234
+  text: 'tlslite-ng version 0.7.3 and earlier, since commit d7b288316bca7bcdd082e6ccff5491e241305233 contains a CWE-354: Improper Validation of Integrity Check Value vulnerability in TLS implementation, tlslite/utils/constanttime.py: ct_check_cbc_mac_and_pad(); line "end_pos = data_len - 1 - mac.digest_size" that can result in an attacker manipulating the TLS ciphertext which will not be detected by receiving tlslite-ng. This attack appears to be exploitable via man in the middle on a network connection. This vulnerability appears to have been fixed after commit 3674815d1b0f7484454995e2737a352e0a6a93d8.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3674815d1b0f7484454995e2737a352e0a6a93d8
+    repository: https://github.com/tomato42/tlslite-ng

--- a/statements/CVE-2018-1000548/statement.yaml
+++ b/statements/CVE-2018-1000548/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-1000548
+notes:
+- links:
+  - https://github.com/umlet/umlet/issues/500
+  - https://snyk.io/vuln/SNYK-JAVA-COMUMLET-32394
+  text: Umlet version < 14.3 contains a XML External Entity (XXE) vulnerability in File parsing that can result in disclosure of confidential data, denial of service, server side request forgery. This attack appear to be exploitable via Specially crafted UXF file. This vulnerability appears to have been fixed in 14.3.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e1c4cc6ae692cc8d1c367460dbf79343e996f9bd
+    repository: https://github.com/umlet/umlet

--- a/statements/CVE-2018-1000809/statement.yaml
+++ b/statements/CVE-2018-1000809/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-1000809
+notes:
+- links:
+  - https://github.com/privacyidea/privacyidea/issues/1227
+  - https://snyk.io/vuln/SNYK-PYTHON-PRIVACYIDEA-72432
+  text: privacyIDEA version 2.23.1 and earlier contains a Improper Input Validation vulnerability in token validation api that can result in Denial-of-Service. This attack appear to be exploitable via http request with user=<space>&pass= to /validate/check url. This vulnerability appears to have been fixed in 2.23.2.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 189312a99b499fe405fd3df5dd03a6b19ba66d46
+    repository: https://github.com/privacyidea/privacyidea

--- a/statements/CVE-2018-1000814/statement.yaml
+++ b/statements/CVE-2018-1000814/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-1000814
+notes:
+- links:
+  - https://github.com/aio-libs/aiohttp-session/issues/325
+  - https://github.com/aio-libs/aiohttp-session/pull/331
+  - https://snyk.io/vuln/SNYK-PYTHON-AIOHTTPSESSION-72728
+  text: aio-libs aiohttp-session version 2.6.0 and earlier contains a Other/Unknown vulnerability in EncryptedCookieStorage and NaClCookieStorage that can result in Non-expiring sessions / Infinite lifespan. This attack appear to be exploitable via Recreation of a cookie post-expiry with the same value.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1b356f01bbab57d041c9a75bacd72fbbf8524728
+    repository: https://github.com/aio-libs/aiohttp-session

--- a/statements/CVE-2018-1000872/statement.yaml
+++ b/statements/CVE-2018-1000872/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-1000872
+notes:
+- links:
+  - https://github.com/OpenKMIP/PyKMIP/issues/430
+  - https://snyk.io/vuln/SNYK-PYTHON-PYKMIP-72725
+  text: 'OpenKMIP PyKMIP version All versions before 0.8.0 contains a CWE 399: Resource Management Errors (similar issue to CVE-2015-5262) vulnerability in PyKMIP server that can result in DOS: the server can be made unavailable by one or more clients opening all of the available sockets. This attack appear to be exploitable via A client or clients open sockets with the server and then never close them. This vulnerability appears to have been fixed in 0.8.0.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 06c960236bcaf6717fc5cf66cf8b5179804c5a05
+    repository: https://github.com/OpenKMIP/PyKMIP

--- a/statements/CVE-2018-1002200/statement.yaml
+++ b/statements/CVE-2018-1002200/statement.yaml
@@ -1,0 +1,30 @@
+vulnerability_id: CVE-2018-1002200
+notes:
+- links:
+  - https://github.com/codehaus-plexus/plexus-archiver/pull/87
+  - https://snyk.io/research/zip-slip-vulnerability
+  text: plexus-archiver before 3.6.0 is vulnerable to directory traversal, allowing attackers to write to arbitrary files via a ../ (dot dot slash) in an archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 58bc24e465c0842981692adbf6d75680298989de
+    repository: https://github.com/codehaus-plexus/plexus-archiver
+artifacts:
+- id: pkg:maven/org.codehaus.plexus/plexus-archiver@2.8.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.codehaus.plexus/plexus-archiver@3.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.codehaus.plexus/plexus-archiver@3.6.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.codehaus.plexus/plexus-archiver@2.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.codehaus.plexus/plexus-archiver@2.1.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/org.codehaus.plexus/plexus-archiver@2.2
+  reason: Reviewed manually
+  affected: true

--- a/statements/CVE-2018-11765/statement.yaml
+++ b/statements/CVE-2018-11765/statement.yaml
@@ -1,0 +1,104 @@
+vulnerability_id: CVE-2018-11765
+notes:
+- links:
+  - https://lists.apache.org/thread.html/r2c7f899911a04164ed1707083fcd4135f8427e04778c87d83509b0da%40%3Cgeneral.hadoop.apache.org%3E
+  text: In Apache Hadoop versions 3.0.0-alpha2 to 3.0.0, 2.9.0 to 2.9.2, 2.8.0 to 2.8.5, any users can access some servlets without authentication when Kerberos authentication is enabled and SPNEGO through HTTP is not enabled.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 94b0df839d36cf5d5e927b3642566c67d0689474
+    repository: https://github.com/apache/hadoop
+artifacts:
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.8.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.7.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.7.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.5.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.5.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.7.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.7.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.8.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.9.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.avro/avro-tools@1.9.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.6.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.7.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.4.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.6.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.6.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.7.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.1.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.8.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.7.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.1.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.8.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.avro/avro-tools@1.8.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.9.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.2.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.1.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.2.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.2.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.1.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@2.10.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.avro/avro-tools@1.9.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.hadoop/hadoop-common@3.3.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-11786/statement.yaml
+++ b/statements/CVE-2018-11786/statement.yaml
@@ -1,0 +1,37 @@
+vulnerability_id: CVE-2018-11786
+notes:
+- links:
+  - https://issues.apache.org/jira/browse/KARAF-5427
+  - https://lists.apache.org/thread.html/5b7ac762c6bbe77ac5d9389f093fc6dbf196c36d788e3d7629e6c1d9@%3Cdev.karaf.apache.org%3E
+  - https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEKARAFSHELL-72392
+  text: In Apache Karaf prior to 4.2.0 release, if the sshd service in Karaf is left on so an administrator can manage the running instance, any user with rights to the Karaf console can pivot and read/write any file on the file system to which the Karaf process user has access. This can be locked down a bit by using chroot to change the root directory to protect files outside of the Karaf install directory; it can be further locked down by defining a security manager policy that limits file system access to those directories beneath the Karaf home that are necessary for the system to run. However, this still allows anyone with ssh access to the Karaf process to read and write a large number of files as the Karaf process user.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 24fb477ea886e8f294dedbad98d2a2c4cb2a44f9
+    repository: https://github.com/apache/karaf
+artifacts:
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.2.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.0.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.0.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.2.0.M2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.2.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.2.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.2.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.karaf.shell/org.apache.karaf.shell.core@4.2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-14505/statement.yaml
+++ b/statements/CVE-2018-14505/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-14505
+notes:
+- links:
+  - https://github.com/mitmproxy/mitmproxy/issues/3234
+  - https://github.com/mitmproxy/mitmproxy/pull/3243
+  - https://snyk.io/vuln/SNYK-PYTHON-MITMPROXY-42179
+  text: mitmweb in mitmproxy v4.0.3 allows DNS Rebinding attacks, related to tools/web/app.py.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7f464b89296881f4d9ec032378c4418e832d17e3
+    repository: https://github.com/mitmproxy/mitmproxy

--- a/statements/CVE-2018-14574/statement.yaml
+++ b/statements/CVE-2018-14574/statement.yaml
@@ -1,0 +1,61 @@
+vulnerability_id: CVE-2018-14574
+notes:
+- links:
+  - https://docs.djangoproject.com/en/2.0/releases/1.11.15/
+  - https://docs.djangoproject.com/en/2.0/releases/2.0.8/
+  - https://www.djangoproject.com/weblog/2018/aug/01/security-releases/
+  text: django.middleware.common.CommonMiddleware in Django 1.11.x before 1.11.15 and 2.0.x before 2.0.8 has an Open Redirect.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a656a681272f8f3734b6eb38e9a88aa0d91806f1
+    repository: https://github.com/django/django
+artifacts:
+- id: pkg:maven/Django/Django@2.0.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Django/Django@2.0.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Django/Django@2.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.0.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Django/Django@2.0.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Django/Django@2.0.6
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Django/Django@2.0.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Django/Django@2.2.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-15560/statement.yaml
+++ b/statements/CVE-2018-15560/statement.yaml
@@ -1,0 +1,37 @@
+vulnerability_id: CVE-2018-15560
+notes:
+- links: []
+  text: PyCryptodome before 3.6.6 has an integer overflow in the data_len variable in AESNI.c, related to the AESNI_encrypt and AESNI_decrypt functions, leading to the mishandling of messages shorter than 16 bytes.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d1739c62b9b845f8a5b342de08d6bf6e2722d247
+    repository: https://github.com/Legrandin/pycryptodome
+artifacts:
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.7
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.7
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.11
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.11
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/pycrypto/pycrypto@2.6.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/pycryptodome/pycryptodome@3.4.11
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/pycryptodome/pycryptodome@3.7.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.8.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/pycryptodome/pycryptodome@3.8.2
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2018-16859/statement.yaml
+++ b/statements/CVE-2018-16859/statement.yaml
@@ -1,0 +1,31 @@
+vulnerability_id: CVE-2018-16859
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2018-16859
+  - https://github.com/ansible/ansible/pull/49142
+  - https://snyk.io/vuln/SNYK-PYTHON-ANSIBLE-72650
+  text: Execution of Ansible playbooks on Windows platforms with PowerShell ScriptBlock logging and Module logging enabled can allow for 'become' passwords to appear in EventLogs in plaintext. A local user with administrator privileges on the machine can view these logs and discover the plaintext password. Ansible Engine 2.8 and older are believed to be vulnerable.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8c1f701e6e9df29fe991f98265e2dd76acca4b8c
+    repository: https://github.com/ansible/ansible
+artifacts:
+- id: pkg:maven/ansible/ansible@2.8.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/ansible/ansible@2.7.12
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/ansible/ansible@2.7.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/ansible/ansible@2.8.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/ansible/ansible@2.8.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/ansible/ansible@2.8.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-17175/statement.yaml
+++ b/statements/CVE-2018-17175/statement.yaml
@@ -1,0 +1,41 @@
+vulnerability_id: CVE-2018-17175
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17175
+  - https://github.com/marshmallow-code/marshmallow/issues/772
+  - https://github.com/marshmallow-code/marshmallow/pull/777
+  - https://github.com/marshmallow-code/marshmallow/pull/782
+  text: In the marshmallow library before 2.15.1 and 3.x before 3.0.0b9 for Python, the schema "only" option treats an empty list as implying no "only" option, which allows a request that was intended to expose no fields to instead expose all fields (if the schema is being filtered dynamically using the "only" option, and there is a user role that produces an empty value for "only").
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d5d9cb22dda6f39117f6f9497a6a66813cb8c64f
+    repository: https://github.com/marshmallow-code/marshmallow
+artifacts:
+- id: pkg:maven/marshmallow/marshmallow@3.0.0b20
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/marshmallow/marshmallow@2.9.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/marshmallow/marshmallow@2.9.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/marshmallow/marshmallow@3.0.0b4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/marshmallow/marshmallow@3.0.0b4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/marshmallow/marshmallow@3.0.0b16
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/marshmallow/marshmallow@3.0.0b18
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/marshmallow/marshmallow@3.0.0rc1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/marshmallow/marshmallow@2.19.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-17187/statement.yaml
+++ b/statements/CVE-2018-17187/statement.yaml
@@ -1,0 +1,121 @@
+vulnerability_id: CVE-2018-17187
+notes:
+- links:
+  - https://issues.apache.org/jira/browse/PROTON-1962
+  - https://mail-archives.apache.org/mod_mbox/qpid-users/201811.mbox/%3CCAFitrpQSV73Vz7rJYfLJK7gvEymZSCR5ooWUeU8j4jzRydk-eg%40mail.gmail.com%3E
+  - https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEQPID-72605
+  text: The Apache Qpid Proton-J transport includes an optional wrapper layer to perform TLS, enabled by use of the 'transport.ssl(...)' methods. Unless a verification mode was explicitly configured, client and server modes previously defaulted as documented to not verifying a peer certificate, with options to configure this explicitly or select a certificate verification mode with or without hostname verification being performed. The latter hostname verifying mode was not implemented in Apache Qpid Proton-J versions 0.3 to 0.29.0, with attempts to use it resulting in an exception. This left only the option to verify the certificate is trusted, leaving such a client vulnerable to Man In The Middle (MITM) attack. Uses of the Proton-J protocol engine which do not utilise the optional transport TLS wrapper are not impacted, e.g. usage within Qpid JMS. Uses of Proton-J utilising the optional transport TLS wrapper layer that wish to enable hostname verification must be upgraded to version 0.30.0 or later and utilise the VerifyMode#VERIFY_PEER_NAME configuration, which is now the default for client mode usage unless configured otherwise.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0cb8ca03cec42120dcfc434561592d89a89a805e
+    repository: https://github.com/apache/qpid-proton-j
+artifacts:
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.14.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.12.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.23.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.25.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.27.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.10.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.13.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.24.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.15.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.16.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.30.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.31.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.32.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.22.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.16.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.26.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.33.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.qpid/proton-j@0.28.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.29.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.qpid/proton-j@0.18.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.15.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/org.apache.activemq/activemq-osgi@5.16.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-18074/statement.yaml
+++ b/statements/CVE-2018-18074/statement.yaml
@@ -1,0 +1,76 @@
+vulnerability_id: CVE-2018-18074
+notes:
+- links:
+  - https://github.com/requests/requests/issues/4716
+  - https://github.com/requests/requests/pull/4718
+  - https://snyk.io/vuln/SNYK-PYTHON-REQUESTS-72435
+  text: The Requests package before 2.20.0 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c45d7c49ea75133e52ab22a8e9e13173938e36ff
+    repository: https://github.com/requests/requests
+artifacts:
+- id: pkg:maven/requests/requests@2.18.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/requests/requests@2.18.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/requests/requests@2.9.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/requests/requests@2.11.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/requests/requests@2.11.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/requests/requests@2.14.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/requests/requests@2.14.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/requests/requests@2.18.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/requests/requests@2.18.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/requests/requests@2.18.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/requests/requests@2.18.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/requests/requests@2.19.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/requests/requests@2.19.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/requests/requests@2.20.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.20.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/requests/requests@2.20.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.20.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/requests/requests@2.21.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/requests/requests@2.21.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/requests/requests@2.22.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/requests/requests@2.23.0
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2018-6188/statement.yaml
+++ b/statements/CVE-2018-6188/statement.yaml
@@ -1,0 +1,50 @@
+vulnerability_id: CVE-2018-6188
+notes:
+- links:
+  - https://www.djangoproject.com/weblog/2018/feb/01/security-releases/
+  text: django.contrib.auth.forms.AuthenticationForm in Django 2.0 before 2.0.2, and 1.11.8 and 1.11.9, allows remote attackers to obtain potentially sensitive information by leveraging data exposure from the confirm_login_allowed() method, as demonstrated by discovering whether a user account is inactive.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: af33fb250e9847f1ca8c0ba0d72671d76659704f
+    repository: https://github.com/django/django
+artifacts:
+- id: pkg:maven/Django/Django@2.2.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.0.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Django/Django@2.0.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.0.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2018-7749/statement.yaml
+++ b/statements/CVE-2018-7749/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2018-7749
+notes:
+- links: []
+  text: The SSH server implementation of AsyncSSH before 1.12.1 does not properly check whether authentication is completed before processing other requests. A customized SSH client can simply skip the authentication step.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 16e6ebfa893167c7d9d3f6dc7a2c0d197e47f43a
+    repository: https://github.com/ronf/asyncssh

--- a/statements/CVE-2018-7750/statement.yaml
+++ b/statements/CVE-2018-7750/statement.yaml
@@ -1,0 +1,23 @@
+vulnerability_id: CVE-2018-7750
+notes:
+- links:
+  - https://github.com/paramiko/paramiko/issues/1175
+  text: transport.py in the SSH server implementation of Paramiko before 1.17.6, 1.18.x before 1.18.5, 2.0.x before 2.0.8, 2.1.x before 2.1.5, 2.2.x before 2.2.3, 2.3.x before 2.3.2, and 2.4.x before 2.4.1 does not properly check whether authentication is completed before processing other requests, as demonstrated by channel-open. A customized SSH client can simply skip the authentication step.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fa29bd8446c8eab237f5187d28787727b4610516
+    repository: https://github.com/paramiko/paramiko
+artifacts:
+- id: pkg:maven/paramiko/paramiko@2.2.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/paramiko/paramiko@2.4.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/paramiko/paramiko@2.2.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/paramiko/paramiko@2.6.0
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2018-7753/statement.yaml
+++ b/statements/CVE-2018-7753/statement.yaml
@@ -1,0 +1,27 @@
+vulnerability_id: CVE-2018-7753
+notes:
+- links:
+  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892252
+  - https://github.com/mozilla/bleach/releases/tag/v2.1.3
+  text: An issue was discovered in Bleach 2.1.x before 2.1.3. Attributes that have URI values weren't properly sanitized if the values contained character entities. Using character entities, it was possible to construct a URI value with a scheme that was not allowed that would slide through unsanitized.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c5df5789ec3471a31311f42c2d19fc2cf21b35ef
+    repository: https://github.com/mozilla/bleach
+artifacts:
+- id: pkg:maven/bleach/bleach@1.4.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/bleach/bleach@1.5.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/bleach/bleach@2.1.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/bleach/bleach@3.0.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/bleach/bleach@3.1.0
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2018-9856/statement.yaml
+++ b/statements/CVE-2018-9856/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-9856
+notes:
+- links:
+  - https://github.com/Kotti/Kotti/issues/551
+  text: Kotti before 1.3.2 and 2.x before 2.0.0b2 has CSRF in the local roles implementation, as demonstrated by triggering a permission change via a /admin-document/@@share request.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 00b56681fa9fb8587869a5e00dcd56503081d3b9
+    repository: https://github.com/Kotti/Kotti

--- a/statements/CVE-2019-1000007/statement.yaml
+++ b/statements/CVE-2019-1000007/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-1000007
+notes:
+- links:
+  - https://github.com/horazont/aioxmpp/pull/268
+  - https://snyk.io/vuln/SNYK-PYTHON-AIOXMPP-73648
+  text: aioxmpp version 0.10.2 and earlier contains a Improper Handling of Structural Elements vulnerability in Stanza Parser, rollback during error processing, aioxmpp.xso.model.guard function that can result in Denial of Service, Other. This attack appears to be exploitable via Remote. A crafted stanza can be sent to an application which uses the vulnerable components to either inject data in a different context or cause the application to reconnect (potentially losing data). This vulnerability appears to have been fixed in 0.10.3.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 29ff0838a40f58efe30a4bbcea95aa8dab7da475
+    repository: https://github.com/horazont/aioxmpp

--- a/statements/CVE-2019-1003010/statement.yaml
+++ b/statements/CVE-2019-1003010/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1003010
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1003010
+  - https://github.com/jenkinsci/git-plugin/commit/f9152d943936b1c6b493dfe750d27f0caa7c0767
+  - https://jenkins.io/security/advisory/2019-01-28/#SECURITY-1095
+  text: A cross-site request forgery vulnerability exists in Jenkins Git Plugin 3.9.1 and earlier in src/main/java/hudson/plugins/git/GitTagAction.java that allows attackers to create a Git tag in a workspace and attach corresponding metadata to a build record.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f9152d943936b1c6b493dfe750d27f0caa7c0767
+    repository: https://github.com/jenkinsci/git-plugin

--- a/statements/CVE-2019-1010083/statement.yaml
+++ b/statements/CVE-2019-1010083/statement.yaml
@@ -1,0 +1,48 @@
+vulnerability_id: CVE-2019-1010083
+notes:
+- links:
+  - https://github.com/pallets/flask/pull/2691
+  - https://www.palletsprojects.com/blog/flask-1-0-released/
+  text: 'The Pallets Project Flask before 1.0 is affected by: unexpected memory usage. The impact is: denial of service. The attack vector is: crafted encoded JSON data. The fixed version is: 1. NOTE: this may overlap CVE-2018-1000656.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 465b48ed4e4af52493df1febe4687f53032a5e0a
+    repository: https://github.com/pallets/flask
+artifacts:
+- id: pkg:maven/Flask/Flask@1.0.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Flask/Flask@0.12.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Flask/Flask@0.11
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Flask/Flask@0.11.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Flask/Flask@0.12
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Flask/Flask@0.12.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Flask/Flask@1.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Flask/Flask@0.12.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Flask/Flask@1.0.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Flask/Flask@1.1.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Flask/Flask@1.0.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Flask/Flask@1.1.1
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2019-10135/statement.yaml
+++ b/statements/CVE-2019-10135/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-10135
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-10135
+  - https://github.com/containerbuildsystem/osbs-client/pull/865
+  - https://src.fedoraproject.org/rpms/osbs-client/c/d9795c0c8ea320096aa9a0ac410dc0d165103b0a?branch=f30
+  text: A flaw was found in the yaml.load() function in the osbs-client versions since 0.46 before 0.56.1. Insecure use of the yaml.load() function allowed the user to load any suspicious object for code execution via the parsing of malicious YAML files.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: dee8ff1ea3a17bc93ead059b9567ae0ff965592c
+    repository: https://github.com/containerbuildsystem/osbs-client

--- a/statements/CVE-2019-10255/statement.yaml
+++ b/statements/CVE-2019-10255/statement.yaml
@@ -1,0 +1,32 @@
+vulnerability_id: CVE-2019-10255
+notes:
+- links:
+  - https://blog.jupyter.org/open-redirect-vulnerability-in-jupyter-jupyterhub-adf43583f1e4
+  - https://nvd.nist.gov/vuln/detail/CVE-2019-10255
+  text: An Open Redirect vulnerability for all browsers in Jupyter Notebook before 5.7.7 and some browsers (Chrome, Firefox) in JupyterHub before 0.9.5 allows crafted links to the login page, which will redirect to a malicious site after successful login. Servers running on a base_url prefix are not affected.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 08c4c898182edbe97aadef1815cce50448f975cb
+    repository: https://github.com/jupyter/notebook
+  - id: 70fe9f0ddb3023162ece21fbb77d5564306b913b
+    repository: https://github.com/jupyter/notebook
+artifacts:
+- id: pkg:maven/notebook/notebook@5.2.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.4.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.6
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.8
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2019-10682/statement.yaml
+++ b/statements/CVE-2019-10682/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-10682
+notes:
+- links:
+  - https://nvd.nist.gov/vuln/detail/CVE-2019-10682
+  text: django-nopassword before 5.0.0 stores cleartext secrets in the database.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d8b4615f5fbfe3997d96cf4cb3e342406396193c
+    repository: https://github.com/relekang/django-nopassword

--- a/statements/CVE-2019-10751/statement.yaml
+++ b/statements/CVE-2019-10751/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2019-10751
+notes:
+- links: []
+  text: All versions of the HTTPie package prior to version 1.0.3 are vulnerable to Open Redirect that allows an attacker to write an arbitrary file with supplied filename and content to the current directory, by redirecting a request from HTTP to a crafted URL pointing to a server in his or hers control.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: df36d6255df5793129b02ac82f1010171bd8a0a8
+    repository: https://github.com/jakubroztocil/httpie

--- a/statements/CVE-2019-10856/statement.yaml
+++ b/statements/CVE-2019-10856/statement.yaml
@@ -1,0 +1,41 @@
+vulnerability_id: CVE-2019-10856
+notes:
+- links:
+  - https://blog.jupyter.org/open-redirect-vulnerability-in-jupyter-jupyterhub-adf43583f1e4
+  text: In Jupyter Notebook before 5.7.8, an open redirect can occur via an empty netloc. This issue exists because of an incomplete fix for CVE-2019-10255.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 979e0bd15e794ceb00cc63737fcd5fd9addc4a99
+    repository: https://github.com/jupyter/notebook
+artifacts:
+- id: pkg:maven/notebook/notebook@5.2.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.4.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.4.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.6
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/notebook/notebook@5.7.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/notebook/notebook@5.7.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2019-11236/statement.yaml
+++ b/statements/CVE-2019-11236/statement.yaml
@@ -1,0 +1,66 @@
+vulnerability_id: CVE-2019-11236
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11236
+  - https://github.com/urllib3/urllib3/issues/1553
+  text: In the urllib3 library through 1.24.1 for Python, CRLF injection is possible if the attacker controls the request parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0aa3e24fcd75f1bb59ab159e9f8adb44055b2271
+    repository: https://github.com/urllib3/urllib3
+- id: 1.24.x
+  commits:
+  - id: 9b76785331243689a9d52cef3db05ef7462cb02
+    repository: https://github.com/urllib3/urllib3
+  - id: efddd7e7bad26188c3b692d1090cba768afa916
+    repository: https://github.com/urllib3/urllib3
+artifacts:
+- id: pkg:maven/urllib3/urllib3@1.22
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.23
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.24
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.24.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.13.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.21.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.24.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.24.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.7
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2019-11324/statement.yaml
+++ b/statements/CVE-2019-11324/statement.yaml
@@ -1,0 +1,56 @@
+vulnerability_id: CVE-2019-11324
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11324
+  text: The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired set of CA certificates is different from the OS store of CA certificates, which results in SSL connections succeeding in situations where a verification failure is the correct outcome. This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1efadf43dc63317cd9eaa3e0fdb9e05ab07254b1
+    repository: https://github.com/urllib3/urllib3
+artifacts:
+- id: pkg:maven/urllib3/urllib3@1.24
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.24.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.22
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.23
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.24.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.24.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.6
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2019-11340/statement.yaml
+++ b/statements/CVE-2019-11340/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-11340
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11340
+  - https://matrix.org/blog/2019/04/18/security-update-sydent-1-0-2/
+  text: util/emailutils.py in Matrix Sydent before 1.0.2 mishandles registration restrictions that are based on e-mail domain, if the allowed_local_3pids option is enabled. This occurs because of potentially unwanted behavior in Python, in which an email.utils.parseaddr call on user@bad.example.net@good.example.com returns the user@bad.example.net substring.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4e1cfff53429c49c87d5c457a18ed435520044fc
+    repository: https://github.com/matrix-org/sydent

--- a/statements/CVE-2019-13177/statement.yaml
+++ b/statements/CVE-2019-13177/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-13177
+notes:
+- links:
+  - https://github.com/apragacz/django-rest-registration/security/advisories/GHSA-p3w6-jcg4-52xh
+  text: verification.py in django-rest-registration (aka Django REST Registration library) before 0.5.0 relies on a static string for signatures (i.e., the Django Signing API is misused), which allows remote attackers to spoof the verification process. This occurs because incorrect code refactoring led to calling a security-critical function with an incorrect argument.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 26d094fab65ea8c2694fdfb6a3ab95a7808b62d5
+    repository: https://github.com/apragacz/django-rest-registration

--- a/statements/CVE-2019-14859/statement.yaml
+++ b/statements/CVE-2019-14859/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-14859
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14859
+  - https://github.com/warner/python-ecdsa/issues/114
+  - https://github.com/warner/python-ecdsa/releases/tag/python-ecdsa-0.13.3
+  text: A flaw was found in all python-ecdsa versions before 0.13.3, where it did not correctly verify whether signatures used DER encoding. Without this verification, a malformed signature could be accepted, making the signature malleable. Without proper verification, an attacker could use a malleable signature to create false transactions.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 434f5dba086995e17dddd8df06007aa5e5dd9dad
+    repository: https://github.com/warner/python-ecdsa

--- a/statements/CVE-2019-14864/statement.yaml
+++ b/statements/CVE-2019-14864/statement.yaml
@@ -1,0 +1,25 @@
+vulnerability_id: CVE-2019-14864
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1764148
+  - https://github.com/ansible/ansible/issues/63522
+  - https://github.com/ansible/ansible/pull/63527
+  text: Ansible, versions 2.9.x before 2.9.1, 2.8.x before 2.8.7 and Ansible versions 2.7.x before 2.7.15, is not respecting the flag no_log set it to True when Sumologic and Splunk callback plugins are used send tasks results events to collectors. This would discloses and collects any sensitive data.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c76e074e4c71c7621a1ca8159261c1959b5287af
+    repository: https://github.com/ansible/ansible
+artifacts:
+- id: pkg:maven/ansible/ansible@2.8.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/ansible/ansible@2.7.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/ansible/ansible@2.8.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/ansible/ansible@2.8.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2019-15486/statement.yaml
+++ b/statements/CVE-2019-15486/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2019-15486
+notes:
+- links: []
+  text: django-js-reverse (aka Django JS Reverse) before 0.9.1 has XSS via js_reverse_inline.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 78d6aff2276f2d341f643b095515f8aaba5e67c2
+    repository: https://github.com/ierror/django-js-reverse

--- a/statements/CVE-2019-17134/statement.yaml
+++ b/statements/CVE-2019-17134/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-17134
+notes:
+- links:
+  - https://security.openstack.org/ossa/OSSA-2019-005.html
+  - https://storyboard.openstack.org/#!/story/2006660
+  text: Amphora Images in OpenStack Octavia >=0.10.0 <2.1.2, >=3.0.0 <3.2.0, >=4.0.0 <4.1.0 allows anyone with access to the management network to bypass client-certificate based authentication and retrieve information or issue configuration commands via simple HTTP requests to the Agent on port https/9443, because the cmd/agent.py gunicorn cert_reqs option is True but is supposed to be ssl.CERT_REQUIRED.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b0c2cd7b4c835c391cfedf12cf9f9ff8a0aabd17
+    repository: https://github.com/openstack/octavia

--- a/statements/CVE-2019-17206/statement.yaml
+++ b/statements/CVE-2019-17206/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-17206
+notes:
+- links:
+  - https://github.com/frostming/rediswrapper/pull/1
+  - https://github.com/frostming/rediswrapper/releases/tag/v0.3.0
+  text: Uncontrolled deserialization of a pickled object in models.py in Frost Ming rediswrapper (aka Redis Wrapper) before 0.3.0 allows attackers to execute arbitrary scripts.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2751f6ff86e3f90c9e14b8b8acc8ef02c86987e1
+    repository: https://github.com/frostming/rediswrapper

--- a/statements/CVE-2019-18835/statement.yaml
+++ b/statements/CVE-2019-18835/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-18835
+notes:
+- links:
+  - https://github.com/matrix-org/synapse/pull/6262
+  - https://github.com/matrix-org/synapse/releases/tag/v1.5.0
+  text: Matrix Synapse before 1.5.0 mishandles signature checking on some federation APIs. Events sent over /send_join, /send_leave, and /invite may not be correctly signed, or may not come from the expected servers.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 172f264ed38e8bef857552f93114b4ee113a880b
+    repository: https://github.com/matrix-org/synapse

--- a/statements/CVE-2019-19911/statement.yaml
+++ b/statements/CVE-2019-19911/statement.yaml
@@ -1,0 +1,87 @@
+vulnerability_id: CVE-2019-19911
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19911
+  - https://pillow.readthedocs.io/en/stable/releasenotes/6.2.2.html
+  text: There is a DoS vulnerability in Pillow before 6.2.2 caused by FpxImagePlugin.py calling the range function on an unvalidated 32-bit integer if the number of bands is large. On Windows running 32-bit Python, this results in an OverflowError or MemoryError due to the 2 GB limit. However, on Linux running 64-bit Python this results in the process being terminated by the OOM killer.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 138bd714f5cb2346af71447f7ec52ed54037bc0b
+    repository: https://github.com/python-pillow/Pillow
+artifacts:
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.3.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.3.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@6.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@6.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@6.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Pillow/Pillow@7.1.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Pillow/Pillow@4.2.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@2.9.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.3.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.4.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@6.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@7.0.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Pillow/Pillow@7.1.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Pillow/Pillow@4.2.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@3.1.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.0.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.2.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@5.4.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Pillow/Pillow@6.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Pillow/Pillow@7.0.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Pillow/Pillow@7.0.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Pillow/Pillow@7.1.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2019-20916/statement.yaml
+++ b/statements/CVE-2019-20916/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-20916
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20916
+  - https://github.com/pypa/pip/issues/6413
+  text: The pip package before 19.2 for Python allows Directory Traversal when a URL is given in an install command, because a Content-Disposition header can have ../ in a filename, as demonstrated by overwriting the /root/.ssh/authorized_keys file. This occurs in _download_http_url in _internal/download.py.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5776ddd05896162e283737d7fcdf8f5a63a97bbc
+    repository: https://github.com/pypa/pip

--- a/statements/CVE-2019-6802/statement.yaml
+++ b/statements/CVE-2019-6802/statement.yaml
@@ -1,0 +1,66 @@
+vulnerability_id: CVE-2019-6802
+notes:
+- links:
+  - https://github.com/pypiserver/pypiserver/issues/237
+  - https://snyk.io/vuln/SNYK-PYTHON-PYPISERVER-73607
+  text: CRLF Injection in pypiserver 1.2.5 and below allows attackers to set arbitrary HTTP headers and possibly conduct XSS attacks via a %0d%0a in a URI.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1375a67c55a9b8d4619df30d2a1c0b239d7357e6
+    repository: https://github.com/pypiserver/pypiserver
+artifacts:
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.3.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.2.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.2.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.7.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.0.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.7.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@1.9
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.1.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.3.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.3.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/cryptography/cryptography@2.4.2
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2019-6975/statement.yaml
+++ b/statements/CVE-2019-6975/statement.yaml
@@ -1,0 +1,41 @@
+vulnerability_id: CVE-2019-6975
+notes:
+- links:
+  - https://docs.djangoproject.com/en/2.1/releases/2.1.6/
+  text: Django 1.11.x before 1.11.19, 2.0.x before 2.0.11, and 2.1.x before 2.1.6 allows Uncontrolled Memory Consumption via a malicious attacker-supplied value to the django.utils.numberformat.format() function.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 402c0caa851e265410fbcaa55318f22d2bf22ee2
+    repository: https://github.com/django/django
+artifacts:
+- id: pkg:maven/Django/Django@2.2.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Django/Django@2.2.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.13
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.14
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Django/Django@2.2.12
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2019-7313/statement.yaml
+++ b/statements/CVE-2019-7313/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-7313
+notes:
+- links:
+  - https://github.com/buildbot/buildbot/pull/4584
+  - https://github.com/buildbot/buildbot/wiki/CRLF-injection-in-Buildbot-login-and-logout-redirect-code
+  - https://snyk.io/vuln/SNYK-PYTHON-BUILDBOT-73642
+  text: www/resource.py in Buildbot before 1.8.1 allows CRLF injection in the Location header of /auth/login and /auth/logout via the redirect parameter. This affects other web sites in the same domain.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f0ccd5fd572ea8223b48bd57d8c2548b2f7d3ecf
+    repository: https://github.com/buildbot/buildbot

--- a/statements/CVE-2019-9740/statement.yaml
+++ b/statements/CVE-2019-9740/statement.yaml
@@ -1,0 +1,59 @@
+vulnerability_id: CVE-2019-9740
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9740
+  - https://github.com/urllib3/urllib3/
+  text: 'An issue was discovered in urllib2 in Python 2.x through 2.7.16 and urllib in Python 3.x through 3.7.3. CRLF injection is possible if the attacker controls a url parameter, as demonstrated by the first argument to urllib.request.urlopen with \r\n (specifically in the query string after a ? character) followed by an HTTP header or a Redis command. This is fixed in: v2.7.17, v2.7.17rc1, v2.7.18, v2.7.18rc1; v3.5.10, v3.5.10rc1, v3.5.8, v3.5.8rc1, v3.5.8rc2, v3.5.9; v3.6.10, v3.6.10rc1, v3.6.11, v3.6.11rc1, v3.6.12, v3.6.9, v3.6.9rc1; v3.7.4, v3.7.4rc1, v3.7.4rc2, v3.7.5, v3.7.5rc1, v3.7.6, v3.7.6rc1, v3.7.7, v3.7.7rc1, v3.7.8, v3.7.8rc1, v3.7.9.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9b76785331243689a9d52cef3db05ef7462cb02d
+    repository: https://github.com/urllib3/urllib3
+  - id: efddd7e7bad26188c3b692d1090cba768afa9162
+    repository: https://github.com/urllib3/urllib3
+artifacts:
+- id: pkg:maven/urllib3/urllib3@1.23
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.22
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.24.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.24
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.24.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.7
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.21.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.24.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.6
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2020-11001/statement.yaml
+++ b/statements/CVE-2020-11001/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-11001
+notes:
+- links:
+  - https://github.com/wagtail/wagtail/security/advisories/GHSA-v2wc-pfq2-5cm6
+  text: In Wagtail before versions 2.8.1 and 2.7.2, a cross-site scripting (XSS) vulnerability exists on the page revision comparison view within the Wagtail admin interface. A user with a limited-permission editor account for the Wagtail admin could potentially craft a page revision history that, when viewed by a user with higher privileges, could perform actions with that user's credentials. The vulnerability is not exploitable by an ordinary site visitor without access to the Wagtail admin. Patched versions have been released as Wagtail 2.7.2 (for the LTS 2.7 branch) and Wagtail 2.8.1 (for the current 2.8 branch).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 61045ceefea114c40ac4b680af58990dbe732389
+    repository: https://github.com/wagtail/wagtail

--- a/statements/CVE-2020-12668/statement.yaml
+++ b/statements/CVE-2020-12668/statement.yaml
@@ -1,0 +1,22 @@
+vulnerability_id: CVE-2020-12668
+notes:
+- links:
+  - https://github.com/HubSpot/jinjava/releases/tag/jinjava-2.5.4
+  text: Jinjava before 2.5.4 allow access to arbitrary classes by calling Java methods on objects passed into a Jinjava context. This could allow for abuse of the application class loader, including Arbitrary File Disclosure.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1b9aaa4b420c58b4a301cf4b7d26207f1c8d1165
+    repository: https://github.com/HubSpot/jinjava
+  - id: 5dfa5b87318744a4d020b66d5f7747acc36b213b
+    repository: https://github.com/HubSpot/jinjava
+artifacts:
+- id: pkg:maven/com.hubspot.jinjava/jinjava@2.4.5
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/com.hubspot.jinjava/jinjava@2.4.15
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/com.hubspot.jinjava/jinjava@2.5.2
+  reason: Reviewed manually
+  affected: true

--- a/statements/CVE-2020-13867/statement.yaml
+++ b/statements/CVE-2020-13867/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-13867
+notes:
+- links:
+  - https://github.com/open-iscsi/targetcli-fb/pull/172
+  text: Open-iSCSI targetcli-fb through 2.1.52 has weak permissions for /etc/target (and for the backup directory and backup files).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 493b62ee9e2b1d827d2faad8c77de6a89c7e21a9
+    repository: https://github.com/open-iscsi/targetcli-fb

--- a/statements/CVE-2020-13940/statement.yaml
+++ b/statements/CVE-2020-13940/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-13940
+notes:
+- links:
+  - https://nifi.apache.org/security#CVE-2020-13940
+  text: In Apache NiFi 1.0.0 to 1.11.4, the notification service manager and various policy authorizer and user group provider objects allowed trusted administrators to inadvertently configure a potentially malicious XML file. The XML file has the ability to make external calls to services (via XXE).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7f0416ee8bdcee95e28409cc6fae9c1394c2a798
+    repository: https://github.com/apache/nifi

--- a/statements/CVE-2020-14019/statement.yaml
+++ b/statements/CVE-2020-14019/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2020-14019
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14019
+  - https://github.com/open-iscsi/rtslib-fb/pull/162
+  text: Open-iSCSI rtslib-fb through 2.1.72 has weak permissions for /etc/target/saveconfig.json because shutil.copyfile (instead of shutil.copy) is used, and thus permissions are not preserved.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b23d061ee0fa7924d2cdce6194c313b9ee06c468
+    repository: https://github.com/open-iscsi/rtslib-fb
+  - id: dffcf83bead64e959505d64ad587768647caab3a
+    repository: https://github.com/open-iscsi/rtslib-fb

--- a/statements/CVE-2020-14365/statement.yaml
+++ b/statements/CVE-2020-14365/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-14365
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1869154
+  text: A flaw was found in the Ansible Engine, in ansible-engine 2.8.x before 2.8.15 and ansible-engine 2.9.x before 2.9.13, when installing packages using the dnf module. GPG signatures are ignored during installation even when disable_gpg_check is set to False, which is the default behavior. This flaw leads to malicious packages being installed on the system and arbitrary code executed via package installation scripts. The highest threat from this vulnerability is to integrity and system availability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1d043e082b3b1f3ad35c803137f5d3bcbae92275
+    repository: https://github.com/ansible/ansible

--- a/statements/CVE-2020-15120/statement.yaml
+++ b/statements/CVE-2020-15120/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2020-15120
+notes:
+- links:
+  - https://github.com/spiral-project/ihatemoney/pull/663
+  - https://github.com/spiral-project/ihatemoney/security/advisories/GHSA-67j9-c52g-w2q9
+  text: In "I hate money" before version 4.1.5, an authenticated member of one project can modify and delete members of another project, without knowledge of this other project's private code. This can be further exploited to access all bills of another project without knowledge of this other project's private code. With the default configuration, anybody is allowed to create a new project. An attacker can create a new project and then use it to become authenticated and exploit this flaw. As such, the exposure is similar to an unauthenticated attack, because it is trivial to become authenticated. This is fixed in version 4.1.5.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7fd18288888b7cc913382da2f3d1020815d74cdf
+    repository: https://github.com/spiral-project/ihatemoney
+  - id: 8d77cf5d5646e1d2d8ded13f0660638f57e98471
+    repository: https://github.com/spiral-project/ihatemoney

--- a/statements/CVE-2020-15147/statement.yaml
+++ b/statements/CVE-2020-15147/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2020-15147
+notes:
+- links:
+  - https://github.com/Cog-Creators/Red-DiscordBot/pull/4183
+  - https://github.com/Cog-Creators/Red-DiscordBot/security/advisories/GHSA-7257-96vg-qf6x
+  text: Red Discord Bot before versions 3.3.12 and 3.4 has a Remote Code Execution vulnerability in the Streams module. This exploit allows Discord users with specifically crafted "going live" messages to inject code into the Streams module's going live message. By abusing this exploit, it's possible to perform destructive actions and/or access sensitive information. As a workaround, unloading the Trivia module with `unload streams` can render this exploit not accessible. It is highly recommended updating to 3.3.12 or 3.4 to completely patch this issue.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bf581b9f9711f89aafe838815e719a54b6b45924
+    repository: https://github.com/Cog-Creators/Red-DiscordBot

--- a/statements/CVE-2020-15163/statement.yaml
+++ b/statements/CVE-2020-15163/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2020-15163
+notes:
+- links:
+  - https://github.com/theupdateframework/tuf/pull/1101
+  - https://github.com/theupdateframework/tuf/pull/885
+  - https://github.com/theupdateframework/tuf/security/advisories/GHSA-f8mr-jv2c-v8mg
+  text: Python TUF (The Update Framework) reference implementation before version 0.12 it will incorrectly trust a previously downloaded root metadata file which failed verification at download time. This allows an attacker who is able to serve multiple new versions of root metadata (i.e. by a person-in-the-middle attack) culminating in a version which has not been correctly signed to control the trust chain for future updates. This is fixed in version 0.12 and newer.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3d342e648fbacdf43a13d7ba8886aaaf07334af7
+    repository: https://github.com/theupdateframework/tuf

--- a/statements/CVE-2020-15239/statement.yaml
+++ b/statements/CVE-2020-15239/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2020-15239
+notes:
+- links:
+  - https://github.com/horazont/xmpp-http-upload/pull/12
+  - https://github.com/horazont/xmpp-http-upload/security/advisories/GHSA-hwv5-w8gm-fq9f
+  text: In xmpp-http-upload before version 0.4.0, when the GET method is attacked, attackers can read files which have a `.data` suffix and which are accompanied by a JSON file with the `.meta` suffix. This can lead to Information Disclosure and in some shared-hosting scenarios also to circumvention of authentication or other limitations on the outbound (GET) traffic. For example, in a scenario where a single server has multiple instances of the application running (with separate DATA_ROOT settings), an attacker who has knowledge about the directory structure is able to read files from any other instance to which the process has read access. If instances have individual authentication (for example, HTTP authentication via a reverse proxy, source IP based filtering) or other restrictions (such as quotas), attackers may circumvent those limits in such a scenario by using the Directory Traversal to retrieve data from the other instances. If the associated XMPP server (or anyone knowing the SECRET_KEY) is malicious, they can write files outside the DATA_ROOT. The files which are written are constrained to have the `.meta` and the `.data` suffixes; the `.meta` file will contain the JSON with the Content-Type of the original request and the `.data` file will contain the payload. The issue is patched in version 0.4.0.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 82056540191e89f0cd697c81f57714c00962ed75
+    repository: https://github.com/horazont/xmpp-http-upload

--- a/statements/CVE-2020-15251/statement.yaml
+++ b/statements/CVE-2020-15251/statement.yaml
@@ -1,0 +1,19 @@
+vulnerability_id: CVE-2020-15251
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15251
+  - https://github.com/MirahezeBots/sopel-channelmgnt/pull/3
+  - https://github.com/MirahezeBots/sopel-channelmgnt/security/advisories/GHSA-j257-jfvv-h3x5
+  - https://phab.bots.miraheze.wiki/T117
+  text: In the Channelmgnt plug-in for Sopel (a Python IRC bot) before version 1.0.3, malicious users are able to op/voice and take over a channel. This is an ACL bypass vulnerability. This plugin is bundled with MirahezeBot-Plugins with versions from 9.0.0 and less than 9.0.2 affected. Version 9.0.2 includes 1.0.3 of channelmgnt, and thus is safe from this vulnerability. See referenced GHSA-23pc-4339-95vg.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fd5da591fed6395702cfc9b74bc95c4dd6997e78
+    repository: https://github.com/MirahezeBots/sopel-channelmgnt
+  - id: 221ddd4852f0acbb9c98824332f7a499d2a3a362
+    repository: https://github.com/MirahezeBots/sopel-channelmgnt
+  - id: 4b7dff2bcf68bb614f9449f6d151f06af5aa1d76
+    repository: https://github.com/MirahezeBots/sopel-channelmgnt
+  - id: 6554cc81101d6892f7dc70012b784ddc7491bb8e
+    repository: https://github.com/MirahezeBots/sopel-channelmgnt

--- a/statements/CVE-2020-15271/statement.yaml
+++ b/statements/CVE-2020-15271/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-15271
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15271
+  text: In lookatme (python/pypi package) versions prior to 2.3.0, the package automatically loaded the built-in "terminal" and "file_loader" extensions. Users that use lookatme to render untrusted markdown may have malicious shell commands automatically run on their system. This is fixed in version 2.3.0. As a workaround, the `lookatme/contrib/terminal.py` and `lookatme/contrib/file_loader.py` files may be manually deleted. Additionally, it is always recommended to be aware of what is being rendered with lookatme.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 72fe36b784b234548d49dae60b840c37f0eb8d84
+    repository: https://github.com/d0c-s4vage/lookatme

--- a/statements/CVE-2020-15275/statement.yaml
+++ b/statements/CVE-2020-15275/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-15275
+notes:
+- links:
+  - https://security-tracker.debian.org/tracker/CVE-2020-15275
+  text: MoinMoin is a wiki engine. In MoinMoin before version 1.9.11, an attacker with write permissions can upload an SVG file that contains malicious javascript. This javascript will be executed in a user's browser when the user is viewing that SVG file on the wiki. Users are strongly advised to upgrade to a patched version. MoinMoin Wiki 1.9.11 has the necessary fixes and also contains other important fixes.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 64e16037a60646a4d834f0203c75481b9c3fa74c
+    repository: https://github.com/moinwiki/moin-1.9

--- a/statements/CVE-2020-15278/statement.yaml
+++ b/statements/CVE-2020-15278/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-15278
+notes:
+- links:
+  - https://github.com/Cog-Creators/Red-DiscordBot/security/advisories/GHSA-mp9m-g7qj-6vqr
+  text: Red Discord Bot before version 3.4.1 has an unauthorized privilege escalation exploit in the Mod module. This exploit allows Discord users with a high privilege level within the guild to bypass hierarchy checks when the application is in a specific condition that is beyond that user's control. By abusing this exploit, it is possible to perform destructive actions within the guild the user has high privileges in. This exploit has been fixed in version 3.4.1. As a workaround, unloading the Mod module with unload mod or, disabling the massban command with command disable global massban can render this exploit not accessible. We still highly recommend updating to 3.4.1 to completely patch this issue.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 726bfd38adfdfaef760412a68e01447b470f438b
+    repository: https://github.com/Cog-Creators/Red-DiscordBot

--- a/statements/CVE-2020-1734/statement.yaml
+++ b/statements/CVE-2020-1734/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2020-1734
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-1734
+  - https://github.com/CVEProject/cvelist/pull/3327
+  - https://github.com/ansible/ansible/issues/67792
+  text: A flaw was found in the pipe lookup plugin of ansible. Arbitrary commands can be run, when the pipe lookup plugin uses subprocess.Popen() with shell=True, by overwriting ansible facts and the variable is not escaped by quote plugin. An attacker could take advantage and run arbitrary commands by overwriting the ansible facts.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a02641c0202a643c9d70475789e3f0d8261ae2ee
+    repository: https://github.com/ansible/ansible
+artifacts:
+- id: pkg:maven/ansible/ansible@2.8.10
+  reason: Reviewed manually
+  affected: true

--- a/statements/CVE-2020-1747/statement.yaml
+++ b/statements/CVE-2020-1747/statement.yaml
@@ -1,0 +1,51 @@
+vulnerability_id: CVE-2020-1747
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1807367
+  - https://github.com/yaml/pyyaml/pull/386
+  text: A vulnerability was discovered in the PyYAML library in versions before 5.3.1, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. An attacker could use this flaw to execute arbitrary code on the system by abusing the python/object/new constructor.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5080ba513377b6355a0502104846ee804656f1e0
+    repository: https://github.com/yaml/pyyaml
+artifacts:
+- id: pkg:maven/PyYAML/PyYAML@5.1b5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.1.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.1.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.2b1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.1b1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.1b3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.1.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.1.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.3b1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/PyYAML/PyYAML@5.3.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2020-25592/statement.yaml
+++ b/statements/CVE-2020-25592/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-25592
+notes:
+- links:
+  - https://www.saltstack.com/blog/on-november-3-2020-saltstack-publicly-disclosed-three-new-cves/
+  text: In SaltStack Salt through 3002, salt-netapi improperly validates eauth credentials and tokens. A user can bypass authentication and invoke Salt SSH.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: daa39c58370641913aa8d5a7a0f44254973dd66b
+    repository: https://github.com/saltstack/salt

--- a/statements/CVE-2020-25689/statement.yaml
+++ b/statements/CVE-2020-25689/statement.yaml
@@ -1,0 +1,20 @@
+vulnerability_id: CVE-2020-25689
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1893070
+  - https://github.com/jboss-remoting/jboss-remoting/pull/236
+  - https://github.com/wildfly/wildfly-core/pull/4308
+  - https://issues.redhat.com/browse/WFCORE-5105
+  text: A memory leak flaw was found in WildFly in all versions up to 21.0.0.Final, where host-controller tries to reconnect in a loop, generating new connections which are not properly closed while not able to connect to domain-controller. This flaw allows an attacker to cause an Out of memory (OOM) issue, leading to a denial of service. The highest threat from this vulnerability is to system availability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5a8a65c2e3310fe0c0143581c677855516148215
+    repository: https://github.com/wildfly/wildfly-core
+artifacts:
+- id: pkg:maven/org.wildfly.core/wildfly-protocol@3.0.8.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/org.wildfly.core/wildfly-protocol@12.0.3.Final
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true

--- a/statements/CVE-2020-26137/statement.yaml
+++ b/statements/CVE-2020-26137/statement.yaml
@@ -1,0 +1,33 @@
+vulnerability_id: CVE-2020-26137
+notes:
+- links:
+  - https://bugs.python.org/issue39603
+  - https://nvd.nist.gov/vuln/detail/CVE-2020-26137
+  text: 'urllib3 before 1.25.9 allows CRLF injection if the attacker controls the HTTP request method, as demonstrated by inserting CR and LF control characters in the first argument of putrequest(). NOTE: this is similar to CVE-2020-26116.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1dd69c5c5982fae7c87a620d487c2ebf7a6b436b
+    repository: https://github.com/urllib3/urllib3
+artifacts:
+- id: pkg:maven/urllib3/urllib3@1.25.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.10
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/urllib3/urllib3@1.25.9
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2020-26232/statement.yaml
+++ b/statements/CVE-2020-26232/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2020-26232
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26232
+  - https://github.com/jupyter-server/jupyter_server/security/advisories/GHSA-grfj-wjv9-4f9v
+  text: Jupyter Server before version 1.0.6 has an Open redirect vulnerability. A maliciously crafted link to a jupyter server could redirect the browser to a different website. All jupyter servers are technically affected, however, these maliciously crafted links can only be reasonably made for known jupyter server hosts. A link to your jupyter server may appear safe, but ultimately redirect to a spoofed server on the public internet.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 61ab548bf9186ab7323d8fa7bd0e12ae23555a28
+    repository: https://github.com/jupyter-server/jupyter_server

--- a/statements/CVE-2020-26244/statement.yaml
+++ b/statements/CVE-2020-26244/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2020-26244
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26244
+  - https://github.com/OpenIDC/pyoidc/releases/tag/1.2.1
+  - https://github.com/OpenIDC/pyoidc/security/advisories/GHSA-4fjv-pmhg-3rfg
+  text: 'Python oic is a Python OpenID Connect implementation. In Python oic before version 1.2.1, there are several related cryptographic issues affecting client implementations that use the library. The issues are: 1) The IdToken signature algorithm was not checked automatically, but only if the expected algorithm was passed in as a kwarg. 2) JWA `none` algorithm was allowed in all flows. 3) oic.consumer.Consumer.parse_authz returns an unverified IdToken. The verification of the token was left to the discretion of the implementator. 4) iat claim was not checked for sanity (i.e. it could be in the future). These issues are patched in version 1.2.1.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 62f8d753fa17c8b1f29f8be639cf0b33afb02498
+    repository: https://github.com/OpenIDC/pyoidc

--- a/statements/CVE-2020-26263/statement.yaml
+++ b/statements/CVE-2020-26263/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2020-26263
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26263
+  - https://github.com/tlsfuzzer/tlslite-ng/pull/438
+  - https://github.com/tlsfuzzer/tlslite-ng/pull/439
+  - https://github.com/tlsfuzzer/tlslite-ng/security/advisories/GHSA-wvcv-832q-fjg7
+  text: 'tlslite-ng is an open source python library that implements SSL and TLS cryptographic protocols. In tlslite-ng before versions 0.7.6 and 0.8.0-alpha39, the code that performs decryption and padding check in RSA PKCS#1 v1.5 decryption is data dependant. In particular, the code has multiple ways in which it leaks information about the decrypted ciphertext. It aborts as soon as the plaintext doesn''t start with 0x00, 0x02. All TLS servers that enable RSA key exchange as well as applications that use the RSA decryption API directly are vulnerable. This is patched in versions 0.7.6 and 0.8.0-alpha39. Note: the patches depend on Python processing the individual bytes in side-channel free manner, this is known to not the case (see reference). As such, users that require side-channel resistance are recommended to use different TLS implementations, as stated in the security policy of tlslite-ng.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c28d6d387bba59d8bd5cb3ba15edc42edf54b368
+    repository: https://github.com/tlsfuzzer/tlslite-ng

--- a/statements/CVE-2020-26280/statement.yaml
+++ b/statements/CVE-2020-26280/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2020-26280
+notes:
+- links:
+  - https://github.com/OpenSlides/OpenSlides/blob/master/CHANGELOG.rst#version-33-2020-12-18
+  - https://github.com/OpenSlides/OpenSlides/pull/5714
+  - https://github.com/OpenSlides/OpenSlides/security/advisories/GHSA-w5wr-98qm-jx92
+  text: OpenSlides is a free, Web-based presentation and assembly system for managing and projecting agenda, motions, and elections of assemblies. OpenSlides version 3.2, due to unsufficient user input validation and escaping, it is vulnerable to persistant cross-site scripting (XSS). In the web applications users can enter rich text in various places, e.g. for personal notes or in motions. These fields can be used to store arbitrary JavaScript Code that will be executed when other users read the respective text. An attacker could utilize this vulnerability be used to manipulate votes of other users, hijack the moderators session or simply disturb the meeting. The vulnerability was introduced with 6eae497abeab234418dfbd9d299e831eff86ed45 on 16.04.2020, which is first included in the 3.2 release. It has been patched in version 3.3 ( in commit f3809fc8a97ee305d721662a75f788f9e9d21938, merged in master on 20.11.2020).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f3809fc8a97ee305d721662a75f788f9e9d21938
+    repository: https://github.com/OpenSlides/OpenSlides

--- a/statements/CVE-2020-26282/statement.yaml
+++ b/statements/CVE-2020-26282/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2020-26282
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26282
+  - https://github.com/browserup/browserup-proxy/security/advisories/GHSA-wmfg-55f9-j8hq
+  text: BrowserUp Proxy allows you to manipulate HTTP requests and responses, capture HTTP content, and export performance data as a HAR file. BrowserUp Proxy works well as a standalone proxy server, but it is especially useful when embedded in Selenium tests. A Server-Side Template Injection was identified in BrowserUp Proxy enabling attackers to inject arbitrary Java EL expressions, leading to unauthenticated Remote Code Execution (RCE) vulnerability. This has been patched in version 2.1.2.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4b38e7a3e20917e5c3329d0d4e9590bed9d578ab
+    repository: https://github.com/browserup/browserup-proxy

--- a/statements/CVE-2020-28473/statement.yaml
+++ b/statements/CVE-2020-28473/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-28473
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-28473
+  text: The package bottle from 0 and before 0.12.19 are vulnerable to Web Cache Poisoning by using a vector called parameter cloaking. When the attacker can separate query parameters using a semicolon (;), they can cause a difference in the interpretation of the request between the proxy (running with default configuration) and the server. This can result in malicious requests being cached as completely safe ones, as the proxy would usually not see the semicolon as a separator, and therefore would not include it in a cache key of an unkeyed parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 57a2f22e0c1d2b328c4f54bf75741d74f47f1a6b
+    repository: https://github.com/bottlepy/bottle

--- a/statements/CVE-2020-28491/statement.yaml
+++ b/statements/CVE-2020-28491/statement.yaml
@@ -1,0 +1,119 @@
+vulnerability_id: CVE-2020-28491
+notes:
+- links:
+  - https://github.com/FasterXML/jackson-dataformats-binary/issues/186
+  text: This affects the package com.fasterxml.jackson.dataformat:jackson-dataformat-cbor from 0 and before 2.11.4, from 2.12.0-rc1 and before 2.12.1. Unchecked allocation of byte buffer can cause a java.lang.OutOfMemoryError exception.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: de072d314af8f5f269c8abec6930652af67bc8e6
+    repository: https://github.com/FasterXML/jackson-dataformats-binary
+artifacts:
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.7.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.6.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.6.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.8
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.7
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.9
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.10.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.8.11
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.10.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.10.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.10.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.6
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.10.5
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.11.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.11.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.10.0.pr2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.12.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.9.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.10.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.11.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.11.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor@2.11.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2020-28493/statement.yaml
+++ b/statements/CVE-2020-28493/statement.yaml
@@ -1,0 +1,33 @@
+vulnerability_id: CVE-2020-28493
+notes:
+- links:
+  - https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py#L20
+  - https://github.com/pallets/jinja/pull/1343
+  text: This affects the package jinja2 from 0.0.0 and before 2.11.3. The ReDoS vulnerability is mainly due to the `_punctuation_re regex` operator and its use of multiple wildcards. The last wildcard is the most exploitable as it searches for trailing punctuation. This issue can be mitigated by Markdown to format user content instead of the urlize filter, or by implementing request timeouts and limiting process memory.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ef658dc3b6389b091d608e710a810ce8b87995b3
+    repository: https://github.com/pallets/jinja
+artifacts:
+- id: pkg:maven/Jinja2/Jinja2@2.11.0
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.11.1
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.11.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Jinja2/Jinja2@2.10
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.10.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.10.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/Jinja2/Jinja2@2.11.2
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: true

--- a/statements/CVE-2020-28724/statement.yaml
+++ b/statements/CVE-2020-28724/statement.yaml
@@ -1,0 +1,48 @@
+vulnerability_id: CVE-2020-28724
+notes:
+- links:
+  - https://github.com/pallets/werkzeug/issues/822
+  - https://github.com/pallets/werkzeug/pull/890/files
+  text: Open redirect vulnerability in werkzeug before 0.11.6 via a double slash in the URL.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 413a978fa99f64d2abdfb8bddd1da5bf44bc52ec
+    repository: https://github.com/pallets/werkzeug
+artifacts:
+- id: pkg:maven/Werkzeug/Werkzeug@0.14.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.11.10
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.12.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.1
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.2
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.3
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.4
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.5
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.15.6
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.16.0
+  reason: Reviewed manually
+  affected: false
+- id: pkg:maven/Werkzeug/Werkzeug@0.16.1
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2020-36242/statement.yaml
+++ b/statements/CVE-2020-36242/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2020-36242
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36242
+  - https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst
+  - https://github.com/pyca/cryptography/issues/5615
+  text: In the cryptography package before 3.3.2 for Python, certain sequences of update calls to symmetrically encrypt multi-GB values could result in an integer overflow and buffer overflow, as demonstrated by the Fernet class.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 06cbf77371881e80ea4b5e349136dcc53749fc0c
+    repository: https://github.com/pyca/cryptography
+artifacts:
+- id: pkg:maven/cryptography/cryptography@3.4.4
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2020-5236/statement.yaml
+++ b/statements/CVE-2020-5236/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2020-5236
+notes:
+- links:
+  - https://github.com/Pylons/waitress/security/advisories/GHSA-73m2-3pwg-5fgc
+  text: 'Waitress version 1.4.2 allows a DOS attack When waitress receives a header that contains invalid characters. When a header like "Bad-header: xxxxxxxxxxxxxxx\x10" is received, it will cause the regular expression engine to catastrophically backtrack causing the process to use 100% CPU time and blocking any other interactions. This allows an attacker to send a single request with an invalid header and take the service offline. This issue was introduced in version 1.4.2 when the regular expression was updated to attempt to match the behaviour required by errata associated with RFC7230. The regular expression that is used to validate incoming headers has been updated in version 1.4.3, it is recommended that people upgrade to the new version of Waitress as soon as possible.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6e46f9e3f014d64dd7d1e258eaf626e39870ee1f
+    repository: https://github.com/Pylons/waitress
+artifacts:
+- id: pkg:maven/waitress/waitress@1.4.3
+  reason: Assessed with Eclipse Steady (AST_EQUALITY)
+  affected: false

--- a/statements/CVE-2020-6174/statement.yaml
+++ b/statements/CVE-2020-6174/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2020-6174
+notes:
+- links:
+  - https://github.com/theupdateframework/tuf/pull/974
+  text: TUF (aka The Update Framework) through 0.12.1 has Improper Verification of a Cryptographic Signature.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a0397c7c820ec1c30ebc793cc9469b61c8d3f50e
+    repository: https://github.com/theupdateframework/tuf

--- a/statements/CVE-2020-7212/statement.yaml
+++ b/statements/CVE-2020-7212/statement.yaml
@@ -1,0 +1,32 @@
+vulnerability_id: CVE-2020-7212
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7212
+  text: The _encode_invalid_chars function in util/url.py in the urllib3 library 1.25.2 through 1.25.7 for Python allows a denial of service (CPU consumption) because of an inefficient algorithm. The percent_encodings array contains all matches of percent encodings. It is not deduplicated. For a URL of length N, the size of percent_encodings may be up to O(N). The next step (normalize existing percent-encoded bytes) also takes up to O(N) for each step, so the total time is O(N^2). If percent_encodings were deduplicated, the time to compute _encode_invalid_chars would be O(kN), where k is at most 484 ((10+6*2)^2).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a2697e7c6b275f05879b60f593c5854a816489f0
+    repository: https://github.com/urllib3/urllib3
+artifacts:
+- id: pkg:maven/urllib3/urllib3@1.25.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.5
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.6
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.7
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/urllib3/urllib3@1.25.8
+  reason: Reviewed manually
+  affected: false

--- a/statements/CVE-2020-9486/statement.yaml
+++ b/statements/CVE-2020-9486/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2020-9486
+notes:
+- links:
+  - https://issues.apache.org/jira/browse/NIFI-7377
+  - https://nifi.apache.org/security#CVE-2020-9486
+  text: In Apache NiFi 1.10.0 to 1.11.4, the NiFi stateless execution engine produced log output which included sensitive property values. When a flow was triggered, the flow definition configuration JSON was printed, potentially containing sensitive values in plaintext.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 148537d64a017b73160b0d49943183c18f883ab0
+    repository: https://github.com/apache/nifi

--- a/statements/CVE-2021-20178/statement.yaml
+++ b/statements/CVE-2021-20178/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2021-20178
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1914774
+  text: ""
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0785772a03470fd2879d2f613520284997dc9dd0
+    repository: https://github.com/ansible/ansible

--- a/statements/CVE-2021-20180/statement.yaml
+++ b/statements/CVE-2021-20180/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2021-20180
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1915808
+  text: ""
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bfea16c4f741d4cd10c8e17bf7eed14240345cb5
+    repository: https://github.com/ansible/ansible

--- a/statements/CVE-2021-20228/statement.yaml
+++ b/statements/CVE-2021-20228/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-20228
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1925002
+  - https://github.com/ansible/ansible/pull/73487
+  text: ""
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e41d1f0a3fd6c466192e7e24accd3d1c6501111b
+    repository: https://github.com/ansible/ansible

--- a/statements/CVE-2021-20250/statement.yaml
+++ b/statements/CVE-2021-20250/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-20250
+notes:
+- links:
+  - https://bugzilla.redhat.com/show_bug.cgi?id=1929479
+  - https://github.com/wildfly/jboss-ejb-client/pull/503
+  text: ""
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 54331f5828b698eae6bff8e1c27f169048c15f8d
+    repository: https://github.com/wildfly/jboss-ejb-client

--- a/statements/CVE-2021-21234/statement.yaml
+++ b/statements/CVE-2021-21234/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-21234
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21234
+  - https://github.com/lukashinsch/spring-boot-actuator-logview/security/advisories/GHSA-p4q6-qxjx-8jgp
+  text: spring-boot-actuator-logview in a library that adds a simple logfile viewer as spring boot actuator endpoint. It is maven package "eu.hinsch:spring-boot-actuator-logview". In spring-boot-actuator-logview before version 0.2.13 there is a directory traversal vulnerability. The nature of this library is to expose a log file directory via admin (spring boot actuator) HTTP endpoints. Both the filename to view and a base folder (relative to the logging folder root) can be specified via request parameters. While the filename parameter was checked to prevent directory traversal exploits (so that `filename=../somefile` would not work), the base folder parameter was not sufficiently checked, so that `filename=somefile&base=../` could access a file outside the logging base directory). The vulnerability has been patched in release 0.2.13. Any users of 0.2.12 should be able to update without any issues as there are no other changes in that release. There is no workaround to fix the vulnerability other than updating or removing the dependency. However, removing read access of the user the application is run with to any directory not required for running the application can limit the impact. Additionally, access to the logview endpoint can be limited by deploying the application behind a reverse proxy.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 760acbb939a8d1f7d1a7dfcd51ca848eea04e772
+    repository: https://github.com/lukashinsch/spring-boot-actuator-logview

--- a/statements/CVE-2021-21236/statement.yaml
+++ b/statements/CVE-2021-21236/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2021-21236
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21236
+  - https://github.com/Kozea/CairoSVG/releases/tag/2.5.1
+  - https://github.com/Kozea/CairoSVG/security/advisories/GHSA-hq37-853p-g5cf
+  text: CairoSVG is a Python (pypi) package. CairoSVG is an SVG converter based on Cairo. In CairoSVG before version 2.5.1, there is a regular expression denial of service (REDoS) vulnerability. When processing SVG files, the python package CairoSVG uses two regular expressions which are vulnerable to Regular Expression Denial of Service (REDoS). If an attacker provides a malicious SVG, it can make cairosvg get stuck processing the file for a very long time. This is fixed in version 2.5.1. See Referenced GitHub advisory for more information.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: cfc9175e590531d90384aa88845052de53d94bf3
+    repository: https://github.com/Kozea/CairoSVG

--- a/statements/CVE-2021-21238/statement.yaml
+++ b/statements/CVE-2021-21238/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-21238
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21238
+  - https://github.com/IdentityPython/pysaml2/security/advisories/GHSA-f4g9-h89h-jgv9
+  text: PySAML2 is a pure python implementation of SAML Version 2 Standard. PySAML2 before 6.5.0 has an improper verification of cryptographic signature vulnerability. All users of pysaml2 that need to validate signed SAML documents are impacted. The vulnerability is a variant of XML Signature wrapping because it did not validate the SAML document against an XML schema. This allowed invalid XML documents to be processed and such a document can trick pysaml2 with a wrapped signature. This is fixed in PySAML2 6.5.0.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1d8fd268f5bf887480a403a7a5ef8f048157cc14
+    repository: https://github.com/IdentityPython/pysaml2

--- a/statements/CVE-2021-21239/statement.yaml
+++ b/statements/CVE-2021-21239/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-21239
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21239
+  - https://github.com/IdentityPython/pysaml2/security/advisories/GHSA-5p3x-r448-pc62
+  text: PySAML2 is a pure python implementation of SAML Version 2 Standard. PySAML2 before 6.5.0 has an improper verification of cryptographic signature vulnerability. Users of pysaml2 that use the default CryptoBackendXmlSec1 backend and need to verify signed SAML documents are impacted. PySAML2 does not ensure that a signed SAML document is correctly signed. The default CryptoBackendXmlSec1 backend is using the xmlsec1 binary to verify the signature of signed SAML documents, but by default xmlsec1 accepts any type of key found within the given document. xmlsec1 needs to be configured explicitly to only use only _x509 certificates_ for the verification process of the SAML document signature. This is fixed in PySAML2 6.5.0.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 46578df0695269a16f1c94171f1429873f90ed99
+    repository: https://github.com/IdentityPython/pysaml2

--- a/statements/CVE-2021-21240/statement.yaml
+++ b/statements/CVE-2021-21240/statement.yaml
@@ -1,0 +1,52 @@
+vulnerability_id: CVE-2021-21240
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21240
+  - https://github.com/httplib2/httplib2/pull/182
+  - https://github.com/httplib2/httplib2/security/advisories/GHSA-93xj-8mrv-444m
+  text: httplib2 is a comprehensive HTTP client library for Python. In httplib2 before version 0.19.0, a malicious server which responds with long series of "\xa0" characters in the "www-authenticate" header may cause Denial of Service (CPU burn while parsing header) of the httplib2 client accessing said server. This is fixed in version 0.19.0 which contains a new implementation of auth headers parsing using the pyparsing library.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bd9ee252c8f099608019709e22c0d705e98d26bc
+    repository: https://github.com/httplib2/httplib2
+artifacts:
+- id: pkg:maven/httplib2/httplib2@0.12.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.9
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.12.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.12.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.13.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.13.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.15.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.17.0
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.17.1
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.17.2
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.17.3
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.17.4
+  reason: Reviewed manually
+  affected: true
+- id: pkg:maven/httplib2/httplib2@0.18.1
+  reason: Reviewed manually
+  affected: true

--- a/statements/CVE-2021-21241/statement.yaml
+++ b/statements/CVE-2021-21241/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-21241
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21241
+  - https://github.com/Flask-Middleware/flask-security/security/advisories/GHSA-hh7m-rx4f-4vpv
+  text: The Python "Flask-Security-Too" package is used for adding security features to your Flask application. It is an is a independently maintained version of Flask-Security based on the 3.0.0 version of Flask-Security. In Flask-Security-Too from version 3.3.0 and before version 3.4.5, the /login and /change endpoints can return the authenticated user's authentication token in response to a GET request. Since GET requests aren't protected with a CSRF token, this could lead to a malicious 3rd party site acquiring the authentication token. Version 3.4.5 and version 4.0.0 are patched. As a workaround, if you aren't using authentication tokens - you can set the SECURITY_TOKEN_MAX_AGE to "0" (seconds) which should make the token unusable.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 61d313150b5f620d0b800896c4f2199005e84b1f
+    repository: https://github.com/Flask-Middleware/flask-security

--- a/statements/CVE-2021-21274/statement.yaml
+++ b/statements/CVE-2021-21274/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-21274
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21274
+  - https://github.com/matrix-org/synapse/security/advisories/GHSA-2hwx-mjrm-v3g8
+  text: Synapse is a Matrix reference homeserver written in python (pypi package matrix-synapse). Matrix is an ecosystem for open federated Instant Messaging and VoIP. In Synapse before version 1.25.0, a malicious homeserver could redirect requests to their .well-known file to a large file. This can lead to a denial of service attack where homeservers will consume significantly more resources when requesting the .well-known file of a malicious homeserver. This affects any server which accepts federation requests from untrusted servers. Issue is resolved in version 1.25.0. As a workaround the `federation_domain_whitelist` setting can be used to restrict the homeservers communicated with over federation.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ff5c4da1289cb5e097902b3e55b771be342c29d6
+    repository: https://github.com/matrix-org/synapse

--- a/statements/CVE-2021-21330/statement.yaml
+++ b/statements/CVE-2021-21330/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2021-21330
+notes:
+- links:
+  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21330
+  - https://github.com/aio-libs/aiohttp/security/advisories/GHSA-v6wp-4m6f-gcjg
+  text: aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. In aiohttp before version 3.7.4 there is an open redirect vulnerability. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. It is caused by a bug in the `aiohttp.web_middlewares.normalize_path_middleware` middleware. This security problem has been fixed in 3.7.4. Upgrade your dependency using pip as follows "pip install aiohttp >= 3.7.4". If upgrading is not an option for you, a workaround can be to avoid using `aiohttp.web_middlewares.normalize_path_middleware` in your applications.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2545222a3853e31ace15d87ae0e2effb7da0c96b
+    repository: https://github.com/aio-libs/aiohttp


### PR DESCRIPTION
## Objective

After #369, the primary goal of this PR is to publish new vulnerability data that has been analyzed with Prospector. Specifically, this PR unveils 133 new statements, the commits of which constitute a strict subset of discoveries made by Prospector.

## Analysis Process

Same as #369. 

## Validation Criteria

Analogous to #369, in order to ensure the maximum degree of confidence when identifying a commit as a patch, we developed a criterion that demands the evaluation of the commit against specific rules. Within this framework, only those commits that exhibited a match with at least one rule possessing a high relevance value qualified as candidates. This prerequisite serves to increase the trustworthiness of the selected commits as legitimate fixes for the vulnerability.

## Ground Truth Validation

In contrast to instances where Prospector identified an exact correspondence with the commits in the dataset, we also aim to publish new statements in which the dataset's commits compose a strict subset of the high-confidence fix commits identified by Prospector. Employing this methodology enables the disclosure of 133 additional statements validated through Prospector. For the initial publication of these new statements, we have decided to release those containing the commits present in the dataset exclusively, without adding any supplementary ones uncovered through Prospector.