### PR TITLE
Fixing issue #373 related to modified-files argument

### DIFF
--- a/prospector/datamodel/advisory.py
+++ b/prospector/datamodel/advisory.py
@@ -319,7 +319,7 @@ def build_advisory_record(
     use_nvd: bool = True,
     publication_date: Optional[str] = None,
     advisory_keywords: Set[str] = set(),
-    modified_files: Optional[str] = None,
+    modified_files: Optional[Set[str]] = None,
 ) -> AdvisoryRecord:
     advisory_record = AdvisoryRecord(
         cve_id=cve_id,
@@ -349,7 +349,7 @@ def build_advisory_record(
         advisory_record.keywords = advisory_keywords
 
     if modified_files and len(modified_files) > 0:
-        advisory_record.files.update(set(modified_files.split(",")))
+        advisory_record.files.update(modified_files)
 
     logger.debug(f"{advisory_record.keywords=}")
     logger.debug(f"{advisory_record.files=}")


### PR DESCRIPTION
Fix for issue #373 related to the usage of modified files.

The usage of `modified-files` generated an AttributeError when creating an advisory record in `build_advisory_record(...)`.
This easy fix changes the `datamodel/advisory.py` file. More specifically, it was necessary to change this part of the code:
```
...
if modified_files and len(modified_files) > 0:
    advisory_record.files.update(set(modified_files.split(",")))
...
```
Since modified_files is already a set at that point of the code, I changed it to:
```
...
if modified_files and len(modified_files) > 0:
    advisory_record.files.update(modified_files)
...
```
I checked other parts of the source code in which modified_files is used. Consequently, I also changed the type annotation related to modified_files in `build_advisory_record(...)`.
As an example, I tested again several different samples. For instance, for `CVE-2021-40690` (the same sample posted in the issue) I tested again the following command:
```
python cli/main.py CVE-2021-40690 --repository https://github.com/apache/santuario-xml-security-java --use-nvd --version-interval 2.2.2:2.2.3 --modified-files KeyInfo,KeyReferenceInfo,RetrievalMethod --use-backend=never --filter-extensions=java
```
After the fix Prospector correctly processes the modified-files argument and provides a report (the report includes all the files that have been specified manually):
```
Initialization   [OK]
Processing advisory   [OK]
Git repository cloning   [OK]
  Fixing commit found in the advisory references

Candidate filtering
   [OK]

Processing commits: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 12/12 [00:03<00:00,  3.07commit/s]
  [OK]
Candidate analysis   [OK]
[OK]
Generating report
   Report saved in prospector-report   [OK]
  Execution time: 19.010s
```