### PR TITLE
Add 307 new statements (exact_tracer)

### DIFF
--- a/statements/CVE-2010-5312/statement.yaml
+++ b/statements/CVE-2010-5312/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2010-5312
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in jquery.ui.dialog.js in the Dialog
+    widget in jQuery UI before 1.10.0 allows remote attackers to inject arbitrary
+    web script or HTML via the title option.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7e9060c109b928769a664dbcc2c17bd21231b6f3
+    repository: https://github.com/jquery/jquery-ui

--- a/statements/CVE-2011-3186/statement.yaml
+++ b/statements/CVE-2011-3186/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2011-3186
+notes:
+- links: []
+  text: CRLF injection vulnerability in actionpack/lib/action_controller/response.rb
+    in Ruby on Rails 2.3.x before 2.3.13 allows remote attackers to inject arbitrary
+    HTTP headers and conduct HTTP response splitting attacks via the Content-Type
+    header.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 11dafeaa7533be26441a63618be93a03869c83a9
+    repository: https://github.com/rails/rails

--- a/statements/CVE-2011-4030/statement.yaml
+++ b/statements/CVE-2011-4030/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2011-4030
+notes:
+- links: []
+  text: The CMFEditions component 2.x in Plone 4.0.x through 4.0.9, 4.1, and 4.2 through
+    4.2a2 does not prevent the KwAsAttributes classes from being publishable, which
+    allows remote attackers to access sub-objects via unspecified vectors, a different
+    vulnerability than CVE-2011-3587.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d55add52e5900967c8cc78becc6790048f02015b
+    repository: https://github.com/plone/Products.CMFEditions

--- a/statements/CVE-2012-1109/statement.yaml
+++ b/statements/CVE-2012-1109/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2012-1109
+notes:
+- links: []
+  text: 'mwlib 0.13 through 0.13.4 has a denial of service vulnerability when parsing
+    #iferror magic functions'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: aa987c281c10e29f26aa0faa21c04f3bb1167fde
+    repository: https://github.com/pediapress/mwlib

--- a/statements/CVE-2012-1176/statement.yaml
+++ b/statements/CVE-2012-1176/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2012-1176
+notes:
+- links: []
+  text: Buffer overflow in the fribidi_utf8_to_unicode function in PyFriBidi before
+    0.11.0 allows remote attackers to cause a denial of service (application crash)
+    via a 4-byte utf-8 sequence.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d2860c655357975e7b32d84e6b45e98f0dcecd7a
+    repository: https://github.com/pediapress/pyfribidi

--- a/statements/CVE-2012-3366/statement.yaml
+++ b/statements/CVE-2012-3366/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2012-3366
+notes:
+- links: []
+  text: The Trigger plugin in bcfg2 1.2.x before 1.2.3 allows remote attackers with
+    root access to the client to execute arbitrary commands via shell metacharacters
+    in the UUID field to the server process (bcfg2-server).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a524967e8d5c4c22e49cd619aed20c87a316c0be
+    repository: https://github.com/Bcfg2/bcfg2

--- a/statements/CVE-2012-3408/statement.yaml
+++ b/statements/CVE-2012-3408/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2012-3408
+notes:
+- links: []
+  text: lib/puppet/network/authstore.rb in Puppet before 2.7.18, and Puppet Enterprise
+    before 2.5.2, supports use of IP addresses in certnames without warning of potential
+    risks, which might allow remote attackers to spoof an agent by acquiring a previously
+    used IP address.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ab9150baa1b738467a33b01df1d90e076253fbbd
+    repository: https://github.com/puppetlabs/puppet

--- a/statements/CVE-2012-6550/statement.yaml
+++ b/statements/CVE-2012-6550/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2012-6550
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in ZeroClipboard before 1.1.4 allows
+    remote attackers to inject arbitrary web script or HTML via "the clipText returned
+    from the flash object," a different vulnerability than CVE-2013-1808.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 51b67b6d696f62aaf003210c08542588222c4913
+    repository: https://github.com/zeroclipboard/zeroclipboard

--- a/statements/CVE-2013-0256/statement.yaml
+++ b/statements/CVE-2013-0256/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-0256
+notes:
+- links: []
+  text: darkfish.js in RDoc 2.3.0 through 3.12 and 4.x before 4.0.0.preview2.1, as
+    used in Ruby, does not properly generate documents, which allows remote attackers
+    to conduct cross-site scripting (XSS) attacks via a crafted URL.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ffa87887ee0517793df7541629a470e331f9fe60
+    repository: https://github.com/ruby/rdoc

--- a/statements/CVE-2013-0294/statement.yaml
+++ b/statements/CVE-2013-0294/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-0294
+notes:
+- links: []
+  text: packet.py in pyrad before 2.1 uses weak random numbers to generate RADIUS
+    authenticators and hash passwords, which makes it easier for remote attackers
+    to obtain sensitive information via a brute force attack.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 38f74b36814ca5b1a27d9898141126af4953bee5
+    repository: https://github.com/pyradius/pyrad

--- a/statements/CVE-2013-1800/statement.yaml
+++ b/statements/CVE-2013-1800/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2013-1800
+notes:
+- links: []
+  text: The crack gem 0.3.1 and earlier for Ruby does not properly restrict casts
+    of string values, which might allow remote attackers to conduct object-injection
+    attacks and execute arbitrary code, or cause a denial of service (memory and CPU
+    consumption) by leveraging Action Pack support for (1) YAML type conversion or
+    (2) Symbol type conversion, a similar vulnerability to CVE-2013-0156.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e3da1212a1f84a898ee3601336d1dbbf118fb5f6
+    repository: https://github.com/jnunemaker/crack

--- a/statements/CVE-2013-1801/statement.yaml
+++ b/statements/CVE-2013-1801/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2013-1801
+notes:
+- links: []
+  text: The httparty gem 0.9.0 and earlier for Ruby does not properly restrict casts
+    of string values, which might allow remote attackers to conduct object-injection
+    attacks and execute arbitrary code, or cause a denial of service (memory and CPU
+    consumption) by leveraging Action Pack support for YAML type conversion, a similar
+    vulnerability to CVE-2013-0156.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 53a812426dd32108d6cba4272b493aa03bc8c031
+    repository: https://github.com/jnunemaker/httparty

--- a/statements/CVE-2013-2013/statement.yaml
+++ b/statements/CVE-2013-2013/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-2013
+notes:
+- links: []
+  text: The user-password-update command in python-keystoneclient before 0.2.4 accepts
+    the new password in the --password argument, which allows local users to obtain
+    sensitive information by listing the process.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f2e0818bc97bfbeba83f6abbb07909a8debcad77
+    repository: https://github.com/openstack/python-keystoneclient

--- a/statements/CVE-2013-2191/statement.yaml
+++ b/statements/CVE-2013-2191/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2013-2191
+notes:
+- links: []
+  text: python-bugzilla before 0.9.0 does not validate X.509 certificates, which allows
+    man-in-the-middle attackers to spoof Bugzilla servers via a crafted certificate.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a782282ee479ba4cc1b8b1d89700ac630ba83eef
+    repository: https://github.com/python-bugzilla/python-bugzilla

--- a/statements/CVE-2013-3300/statement.yaml
+++ b/statements/CVE-2013-3300/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2013-3300
+notes:
+- links: []
+  text: The JsonParser class in json/JsonParser.scala in Lift before 2.5 interprets
+    a certain end-index value as a length value, which allows remote authenticated
+    users to obtain sensitive information from other users' sessions via invalid input
+    data containing a < (less than) character.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 099d9c86cf6d81f4953957add478ab699946e601
+    repository: https://github.com/lift/framework

--- a/statements/CVE-2013-4116/statement.yaml
+++ b/statements/CVE-2013-4116/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-4116
+notes:
+- links: []
+  text: lib/npm.js in Node Packaged Modules (npm) before 1.3.3 allows local users
+    to overwrite arbitrary files via a symlink attack on temporary files with predictable
+    names that are created when unpacking archives.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f4d31693e73a963574a88000580db1a716fe66f1
+    repository: https://github.com/npm/npm

--- a/statements/CVE-2013-4413/statement.yaml
+++ b/statements/CVE-2013-4413/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-4413
+notes:
+- links: []
+  text: Directory traversal vulnerability in controller/concerns/render_redirect.rb
+    in the Wicked gem before 1.0.1 for Ruby allows remote attackers to read arbitrary
+    files via a %2E%2E%2F (encoded dot dot slash) in the step.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fe31bb2533fffc9d098c69ebeb7afc3b80509f53
+    repository: https://github.com/zombocom/wicked

--- a/statements/CVE-2013-4562/statement.yaml
+++ b/statements/CVE-2013-4562/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-4562
+notes:
+- links: []
+  text: The omniauth-facebook gem 1.4.1 before 1.5.0 does not properly store the session
+    parameter, which allows remote attackers to conduct cross-site request forgery
+    (CSRF) attacks via the state parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ccfcc26fe7e34acbd75ad4a095fd01ce5ff48ee7
+    repository: https://github.com/simi/omniauth-facebook

--- a/statements/CVE-2013-4701/statement.yaml
+++ b/statements/CVE-2013-4701/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2013-4701
+notes:
+- links: []
+  text: Auth/Yadis/XML.php in PHP OpenID Library 2.2.2 and earlier allows remote attackers
+    to read arbitrary files, send HTTP requests to intranet servers, or cause a denial
+    of service (CPU and memory consumption) via XRDS data containing an external entity
+    declaration in conjunction with an entity reference, related to an XML External
+    Entity (XXE) issue.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 625c16bb28bb120d262b3f19f89c2c06cb9b0da9
+    repository: https://github.com/openid/php-openid

--- a/statements/CVE-2013-6465/statement.yaml
+++ b/statements/CVE-2013-6465/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-6465
+notes:
+- links: []
+  text: Multiple cross-site scripting (XSS) vulnerabilities in JBPM KIE Workbench
+    6.0.x allow remote authenticated users to inject arbitrary web script or HTML
+    via vectors related to task name html inputs.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4818204506e8e94645b52adb9426bedfa9ffdd04
+    repository: https://github.com/kiegroup/jbpm-wb

--- a/statements/CVE-2013-7378/statement.yaml
+++ b/statements/CVE-2013-7378/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2013-7378
+notes:
+- links: []
+  text: scripts/email.coffee in the Hubot Scripts module before 2.4.4 for Node.js
+    allows remote attackers to execute arbitrary commands.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: feee5abdb038a229a98969ae443cdb8a61747782
+    repository: https://github.com/github/hubot-scripts

--- a/statements/CVE-2013-7459/statement.yaml
+++ b/statements/CVE-2013-7459/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2013-7459
+notes:
+- links: []
+  text: Heap-based buffer overflow in the ALGnew function in block_templace.c in Python
+    Cryptography Toolkit (aka pycrypto) allows remote attackers to execute arbitrary
+    code as demonstrated by a crafted iv parameter to cryptmsg.py.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8dbe0dc3eea5c689d4f76b37b93fe216cf1f00d4
+    repository: https://github.com/pycrypto/pycrypto

--- a/statements/CVE-2014-0072/statement.yaml
+++ b/statements/CVE-2014-0072/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2014-0072
+notes:
+- links: []
+  text: ios/CDVFileTransfer.m in the Apache Cordova File-Transfer standalone plugin
+    (org.apache.cordova.file-transfer) before 0.4.2 for iOS and the File-Transfer
+    plugin for iOS from Cordova 2.4.0 through 2.9.0 might allow remote attackers to
+    spoof SSL servers by leveraging a default value of true for the trustAllHosts
+    option.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a1d6fc07e8a40c1b2b16f4103c403b30e1089668
+    repository: https://github.com/apache/cordova-plugin-file-transfer

--- a/statements/CVE-2014-0073/statement.yaml
+++ b/statements/CVE-2014-0073/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2014-0073
+notes:
+- links: []
+  text: 'The CDVInAppBrowser class in the Apache Cordova In-App-Browser standalone
+    plugin (org.apache.cordova.inappbrowser) before 0.3.2 for iOS and the In-App-Browser
+    plugin for iOS from Cordova 2.6.0 through 2.9.0 does not properly validate callback
+    identifiers, which allows remote attackers to execute arbitrary JavaScript in
+    the host page and consequently gain privileges via a crafted gap-iab: URI.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 26702cb0720c5c394b407c23570136c53171fa55
+    repository: https://github.com/apache/cordova-plugin-inappbrowser

--- a/statements/CVE-2014-0120/statement.yaml
+++ b/statements/CVE-2014-0120/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-0120
+notes:
+- links: []
+  text: Cross-site request forgery (CSRF) vulnerability in the admin terminal in Hawt.io
+    allows remote attackers to hijack the authentication of arbitrary users for requests
+    that run commands on the Karaf server, as demonstrated by running "shutdown -f."
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b4e23e002639c274a2f687ada980118512f06113
+    repository: https://github.com/hawtio/hawtio

--- a/statements/CVE-2014-0160/statement.yaml
+++ b/statements/CVE-2014-0160/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2014-0160
+notes:
+- links: []
+  text: The (1) TLS and (2) DTLS implementations in OpenSSL 1.0.1 before 1.0.1g do
+    not properly handle Heartbeat Extension packets, which allows remote attackers
+    to obtain sensitive information from process memory via crafted packets that trigger
+    a buffer over-read, as demonstrated by reading private keys, related to d1_both.c
+    and t1_lib.c, aka the Heartbleed bug.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 96db9023b881d7cd9f379b0c154650d6c108e9a3
+    repository: https://github.com/openssl/openssl

--- a/statements/CVE-2014-0177/statement.yaml
+++ b/statements/CVE-2014-0177/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2014-0177
+notes:
+- links: []
+  text: The am function in lib/hub/commands.rb in hub before 1.12.1 allows local users
+    to overwrite arbitrary files via a symlink attack on a temporary patch file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 016ec99d25b1cb83cb4367e541177aa431beb600
+    repository: https://github.com/github/hub

--- a/statements/CVE-2014-0228/statement.yaml
+++ b/statements/CVE-2014-0228/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2014-0228
+notes:
+- links: []
+  text: Apache Hive before 0.13.1, when in SQL standards based authorization mode,
+    does not properly check the file permissions for (1) import and (2) export statements,
+    which allows remote authenticated users to obtain sensitive information via a
+    crafted URI.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c3d7083b7605d1753946c4c4411e3a3241ea7ffe
+    repository: https://github.com/apache/hive

--- a/statements/CVE-2014-1202/statement.yaml
+++ b/statements/CVE-2014-1202/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2014-1202
+notes:
+- links: []
+  text: The WSDL/WADL import functionality in SoapUI before 4.6.4 allows remote attackers
+    to execute arbitrary Java code via a crafted request parameter in a WSDL file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6373165649ad74257493c69dbc0569caa7e6b4a6
+    repository: https://github.com/SmartBear/soapui

--- a/statements/CVE-2014-1403/statement.yaml
+++ b/statements/CVE-2014-1403/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-1403
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in name.html in easyXDM before 2.4.19
+    allows remote attackers to inject arbitrary web script or HTML via the location.hash
+    value.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a3194d32c25a0d27a10a47304eb9c9be93ffbf13
+    repository: https://github.com/oyvindkinsey/easyXDM

--- a/statements/CVE-2014-1604/statement.yaml
+++ b/statements/CVE-2014-1604/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-1604
+notes:
+- links: []
+  text: The parser cache functionality in parsergenerator.py in RPLY (aka python-rply)
+    before 0.7.1 allows local users to spoof cache data by pre-creating a temporary
+    rply-*.json file with a predictable name.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fc9bbcd25b0b4f09bbd6339f710ad24c129d5d7c
+    repository: https://github.com/alex/rply

--- a/statements/CVE-2014-3599/statement.yaml
+++ b/statements/CVE-2014-3599/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2014-3599
+notes:
+- links: []
+  text: HornetQ REST is vulnerable to XML External Entity due to insecure configuration
+    of RestEasy
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b3a63576371828d5f8e64ba7ccbcecb1da8111d2
+    repository: https://github.com/hornetq/hornetq

--- a/statements/CVE-2014-3741/statement.yaml
+++ b/statements/CVE-2014-3741/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-3741
+notes:
+- links: []
+  text: The printDirect function in lib/printer.js in the node-printer module 0.0.1
+    and earlier for Node.js allows remote attackers to execute arbitrary commands
+    via unspecified characters in the lpr command.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e001e38738c17219a1d9dd8c31f7d82b9c0013c7
+    repository: https://github.com/tojocky/node-printer

--- a/statements/CVE-2014-4657/statement.yaml
+++ b/statements/CVE-2014-4657/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-4657
+notes:
+- links: []
+  text: The safe_eval function in Ansible before 1.5.4 does not properly restrict
+    the code subset, which allows remote attackers to execute arbitrary code via crafted
+    instructions.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 998793fd0ab55705d57527a38cee5e83f535974c
+    repository: https://github.com/ansible/ansible

--- a/statements/CVE-2014-6394/statement.yaml
+++ b/statements/CVE-2014-6394/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2014-6394
+notes:
+- links: []
+  text: visionmedia send before 0.8.4 for Node.js uses a partial comparison for verifying
+    whether a directory is within the document root, which allows remote attackers
+    to access restricted directories, as demonstrated using "public-restricted" under
+    a "public" directory.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a
+    repository: https://github.com/pillarjs/send

--- a/statements/CVE-2014-7192/statement.yaml
+++ b/statements/CVE-2014-7192/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-7192
+notes:
+- links: []
+  text: Eval injection vulnerability in index.js in the syntax-error package before
+    1.1.1 for Node.js 0.10.x, as used in IBM Rational Application Developer and other
+    products, allows remote attackers to execute arbitrary code via a crafted file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9aa4e66eb90ec595d2dba55e6f9c2dd9a668b309
+    repository: https://github.com/browserify/syntax-error

--- a/statements/CVE-2014-7193/statement.yaml
+++ b/statements/CVE-2014-7193/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2014-7193
+notes:
+- links: []
+  text: The Crumb plugin before 3.0.0 for Node.js does not properly restrict token
+    access in situations where a hapi route handler has CORS enabled, which allows
+    remote attackers to obtain sensitive information, and potentially obtain the ability
+    to spoof requests to non-CORS routes, via a crafted web site that is visited by
+    an application consumer.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5e6d4f5c81677fe9e362837ffd4a02394303db3c
+    repository: https://github.com/hapijs/crumb

--- a/statements/CVE-2014-8115/statement.yaml
+++ b/statements/CVE-2014-8115/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-8115
+notes:
+- links: []
+  text: The default authorization constrains in KIE Workbench 6.0.x allows remote
+    authenticated users to read or write to arbitrary files, bypass intended access
+    restrictions, and possibly have other unspecified impact via unknown vectors.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 90eed433d36b21265fdf978252b8619766b8e74b
+    repository: https://github.com/kiegroup/kie-wb-distributions

--- a/statements/CVE-2014-8152/statement.yaml
+++ b/statements/CVE-2014-8152/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2014-8152
+notes:
+- links: []
+  text: Apache Santuario XML Security for Java 2.0.x before 2.0.3 allows remote attackers
+    to bypass the streaming XML signature protection mechanism via a crafted XML document.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3d7086c603a4538933dfa98d697d0df4539a984f
+    repository: https://github.com/apache/santuario-xml-security-java

--- a/statements/CVE-2014-8681/statement.yaml
+++ b/statements/CVE-2014-8681/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2014-8681
+notes:
+- links: []
+  text: SQL injection vulnerability in the GetIssues function in models/issue.go in
+    Gogs (aka Go Git Service) 0.3.1-9 through 0.5.6.x before 0.5.6.1025 Beta allows
+    remote attackers to execute arbitrary SQL commands via the label parameter to
+    user/repos/issues.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 83283bca4cb4e0f4ec48a28af680f0d88db3d2c8
+    repository: https://github.com/gogs/gogs

--- a/statements/CVE-2014-8682/statement.yaml
+++ b/statements/CVE-2014-8682/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2014-8682
+notes:
+- links: []
+  text: Multiple SQL injection vulnerabilities in Gogs (aka Go Git Service) 0.3.1-9
+    through 0.5.x before 0.5.6.1105 Beta allow remote attackers to execute arbitrary
+    SQL commands via the q parameter to (1) api/v1/repos/search, which is not properly
+    handled in models/repo.go, or (2) api/v1/users/search, which is not properly handled
+    in models/user.go.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0c5ba4573aecc9eaed669e9431a70a5d9f184b8d
+    repository: https://github.com/gogs/gogs

--- a/statements/CVE-2014-9130/statement.yaml
+++ b/statements/CVE-2014-9130/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-9130
+notes:
+- links: []
+  text: scanner.c in LibYAML 0.1.5 and 0.1.6, as used in the YAML-LibYAML (aka YAML-XS)
+    module for Perl, allows context-dependent attackers to cause a denial of service
+    (assertion failure and crash) via vectors involving line-wrapping.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e6aa721cc0e5a48f408c52355559fd36780ba32a
+    repository: https://github.com/yaml/libyaml

--- a/statements/CVE-2014-9489/statement.yaml
+++ b/statements/CVE-2014-9489/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2014-9489
+notes:
+- links: []
+  text: The gollum-grit_adapter Ruby gem dependency in gollum before 3.1.1 and the
+    gollum-lib gem dependency in gollum-lib before 4.0.1 when the string "master"
+    is in any of the wiki documents, allows remote authenticated users to execute
+    arbitrary code via the -O or --open-files-in-pager flags.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4520d973c81fecfebbeacd2ef2f1849d763951c7
+    repository: https://github.com/gollum/grit_adapter

--- a/statements/CVE-2014-9682/statement.yaml
+++ b/statements/CVE-2014-9682/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-9682
+notes:
+- links: []
+  text: The dns-sync module before 0.1.1 for node.js allows context-dependent attackers
+    to execute arbitrary commands via shell metacharacters in the first argument to
+    the resolve API function.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d9abaae384b198db1095735ad9c1c73d7b890a0d
+    repository: https://github.com/skoranga/node-dns-sync

--- a/statements/CVE-2014-9721/statement.yaml
+++ b/statements/CVE-2014-9721/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2014-9721
+notes:
+- links: []
+  text: libzmq before 4.0.6 and 4.1.x before 4.1.1 allows remote attackers to conduct
+    downgrade attacks and bypass ZMTP v3 protocol security mechanisms via a ZMTP v2
+    or earlier header.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b6e3e0f601e2c1ec1f3aac880ed6a3fe63043e51
+    repository: https://github.com/zeromq/zeromq4-x

--- a/statements/CVE-2015-0276/statement.yaml
+++ b/statements/CVE-2015-0276/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2015-0276
+notes:
+- links: []
+  text: Cross-site request forgery (CSRF) vulnerability in Kallithea before 0.2.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 68183cc8e48e4e4fee8510ee819f903b3af3a01b
+    repository: https://github.com/zhumengyuan/kallithea

--- a/statements/CVE-2015-0838/statement.yaml
+++ b/statements/CVE-2015-0838/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-0838
+notes:
+- links: []
+  text: Buffer overflow in the C implementation of the apply_delta function in _pack.c
+    in Dulwich before 0.9.9 allows remote attackers to execute arbitrary code via
+    a crafted pack file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b25e8390074060ea2aed25cf070b8e98b85a3875
+    repository: https://github.com/dulwich/dulwich

--- a/statements/CVE-2015-0846/statement.yaml
+++ b/statements/CVE-2015-0846/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-0846
+notes:
+- links: []
+  text: django-markupfield before 1.3.2 uses the default docutils RESTRUCTUREDTEXT_FILTER_SETTINGS
+    settings, which allows remote attackers to include and read arbitrary files via
+    unspecified vectors.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b45734ea1d206abc1ed2a90bdc779708066d49f3
+    repository: https://github.com/jamesturk/django-markupfield

--- a/statements/CVE-2015-1782/statement.yaml
+++ b/statements/CVE-2015-1782/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-1782
+notes:
+- links: []
+  text: The kex_agree_methods function in libssh2 before 1.5.0 allows remote servers
+    to cause a denial of service (crash) or have other unspecified impact via crafted
+    length values in an SSH_MSG_KEXINIT packet.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7d94b69b802c03e8d7726f4ae61baba52cb7d871
+    repository: https://github.com/libssh2/libssh2

--- a/statements/CVE-2015-3206/statement.yaml
+++ b/statements/CVE-2015-3206/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-3206
+notes:
+- links: []
+  text: The checkPassword function in python-kerberos does not authenticate the KDC
+    it attempts to communicate with, which allows remote attackers to cause a denial
+    of service (bad response), or have other unspecified impact by performing a man-in-the-middle
+    attack.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 02d13860b25fab58e739f0e000bed0067b7c6f9c
+    repository: https://github.com/02strich/pykerberos

--- a/statements/CVE-2015-3220/statement.yaml
+++ b/statements/CVE-2015-3220/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2015-3220
+notes:
+- links: []
+  text: The tlslite library before 0.4.9 for Python allows remote attackers to trigger
+    a denial of service (runtime exception and process crash).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: aca8d4f898b436ff6754e1a9ab96cae976c8a853
+    repository: https://github.com/trevp/tlslite

--- a/statements/CVE-2015-4082/statement.yaml
+++ b/statements/CVE-2015-4082/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-4082
+notes:
+- links: []
+  text: attic before 0.15 does not confirm unencrypted backups with the user, which
+    allows remote attackers with read and write privileges for the encrypted repository
+    to obtain potentially sensitive information by changing the manifest type byte
+    of the repository to "unencrypted / without key file".
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 78f9ad1faba7193ca7f0acccbc13b1ff6ebf9072
+    repository: https://github.com/jborg/attic

--- a/statements/CVE-2015-4410/statement.yaml
+++ b/statements/CVE-2015-4410/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-4410
+notes:
+- links: []
+  text: The Moped::BSON::ObjecId.legal? method in rubygem-moped before commit dd5a7c14b5d2e466f7875d079af71ad19774609b
+    allows remote attackers to cause a denial of service (worker resource consumption)
+    or perform a cross-site scripting (XSS) attack via a crafted string.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: dd5a7c14b5d2e466f7875d079af71ad19774609b
+    repository: https://github.com/mongoid/moped

--- a/statements/CVE-2015-4619/statement.yaml
+++ b/statements/CVE-2015-4619/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2015-4619
+notes:
+- links: []
+  text: Cross-site request forgery (CSRF) vulnerability in Spina before commit bfe44f289e336f80b6593032679300c493735e75.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bfe44f289e336f80b6593032679300c493735e75
+    repository: https://github.com/denkGroot/Spina

--- a/statements/CVE-2015-5147/statement.yaml
+++ b/statements/CVE-2015-5147/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-5147
+notes:
+- links: []
+  text: Stack-based buffer overflow in the header_anchor function in the HTML renderer
+    in Redcarpet before 3.3.2 allows attackers to cause a denial of service (crash)
+    and possibly execute arbitrary code via unspecified vectors.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2cee777c1e5babe8a1e2683d31ea75cc4afe55fb
+    repository: https://github.com/vmg/redcarpet

--- a/statements/CVE-2015-6584/statement.yaml
+++ b/statements/CVE-2015-6584/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-6584
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in the DataTables plugin 1.10.8 and
+    earlier for jQuery allows remote attackers to inject arbitrary web script or HTML
+    via the scripts parameter to media/unit_testing/templates/6776.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ccf86dc5982bd8e16d11a0815c940f5b256874c9
+    repository: https://github.com/DataTables/DataTablesSrc

--- a/statements/CVE-2015-6826/statement.yaml
+++ b/statements/CVE-2015-6826/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-6826
+notes:
+- links: []
+  text: The ff_rv34_decode_init_thread_copy function in libavcodec/rv34.c in FFmpeg
+    before 2.7.2 does not initialize certain structure members, which allows remote
+    attackers to cause a denial of service (invalid pointer access) or possibly have
+    unspecified other impact via crafted (1) RV30 or (2) RV40 RealVideo data.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3197c0aa87a3b7190e17d49e6fbc7b554e4b3f0a
+    repository: https://github.com/FFmpeg/FFmpeg

--- a/statements/CVE-2015-7294/statement.yaml
+++ b/statements/CVE-2015-7294/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2015-7294
+notes:
+- links: []
+  text: ldapauth-fork before 2.3.3 allows remote attackers to perform LDAP injection
+    attacks via a crafted username.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3feea43e243698bcaeffa904a7324f4d96df60e4
+    repository: https://github.com/vesse/node-ldapauth-fork

--- a/statements/CVE-2015-7541/statement.yaml
+++ b/statements/CVE-2015-7541/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-7541
+notes:
+- links: []
+  text: The initialize method in the Histogram class in lib/colorscore/histogram.rb
+    in the colorscore gem before 0.0.5 for Ruby allows context-dependent attackers
+    to execute arbitrary code via shell metacharacters in the (1) image_path, (2)
+    colors, or (3) depth variable.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 570b5e854cecddd44d2047c44126aed951b61718
+    repository: https://github.com/quadule/colorscore

--- a/statements/CVE-2015-7809/statement.yaml
+++ b/statements/CVE-2015-7809/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-7809
+notes:
+- links: []
+  text: The displayBlock function Template.php in Sensio Labs Twig before 1.20.0,
+    when Sandbox mode is enabled, allows remote attackers to execute arbitrary code
+    via the _self variable in a template.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 30be07759a3de2558da5224f127d052ecf492e8f
+    repository: https://github.com/fabpot/Twig

--- a/statements/CVE-2015-8309/statement.yaml
+++ b/statements/CVE-2015-8309/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2015-8309
+notes:
+- links: []
+  text: Directory traversal vulnerability in Cherry Music before 0.36.0 allows remote
+    authenticated users to read arbitrary files via the "value" parameter to "download."
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 62dec34a1ea0741400dd6b6c660d303dcd651e86
+    repository: https://github.com/devsnd/cherrymusic

--- a/statements/CVE-2015-8310/statement.yaml
+++ b/statements/CVE-2015-8310/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-8310
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in Cherry Music before 0.36.0 allows
+    remote authenticated users to inject arbitrary web script or HTML via the playlistname
+    field when creating a new playlist.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 62dec34a1ea0741400dd6b6c660d303dcd651e86
+    repository: https://github.com/devsnd/cherrymusic

--- a/statements/CVE-2015-8747/statement.yaml
+++ b/statements/CVE-2015-8747/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2015-8747
+notes:
+- links: []
+  text: The multifilesystem storage backend in Radicale before 1.1 allows remote attackers
+    to read or write to arbitrary files via a crafted component name.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bcaf452e516c02c9bed584a73736431c5e8831f1
+    repository: https://github.com/Unrud/Radicale

--- a/statements/CVE-2015-8814/statement.yaml
+++ b/statements/CVE-2015-8814/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2015-8814
+notes:
+- links: []
+  text: Umbraco before 7.4.0 allows remote attackers to bypass anti-forgery security
+    measures and conduct cross-site request forgery (CSRF) attacks as demonstrated
+    by editing user account information in the templates.asmx.cs file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 18c3345e47663a358a042652e697b988d6a380eb
+    repository: https://github.com/umbraco/Umbraco-CMS

--- a/statements/CVE-2015-8854/statement.yaml
+++ b/statements/CVE-2015-8854/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-8854
+notes:
+- links: []
+  text: The marked package before 0.3.4 for Node.js allows attackers to cause a denial
+    of service (CPU consumption) via unspecified vectors that trigger a "catastrophic
+    backtracking issue for the em inline rule," aka a "regular expression denial of
+    service (ReDoS)."
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a37bd643f05bf95ff18cafa2b06e7d741d2e2157
+    repository: https://github.com/markedjs/marked

--- a/statements/CVE-2015-9235/statement.yaml
+++ b/statements/CVE-2015-9235/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-9235
+notes:
+- links: []
+  text: In jsonwebtoken node module before 4.2.2 it is possible for an attacker to
+    bypass verification when a token digitally signed with an asymmetric key (RS/ES
+    family) of algorithms but instead the attacker send a token digitally signed with
+    a symmetric algorithm (HS* family).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1bb584bc382295eeb7ee8c4452a673a77a68b687
+    repository: https://github.com/auth0/node-jsonwebtoken

--- a/statements/CVE-2015-9241/statement.yaml
+++ b/statements/CVE-2015-9241/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2015-9241
+notes:
+- links: []
+  text: Certain input passed into the If-Modified-Since or Last-Modified headers will
+    cause an 'illegal access' exception to be raised. Instead of sending a HTTP 500
+    error back to the sender, hapi node module before 11.1.3 will continue to hold
+    the socket open until timed out (default node timeout is 2 minutes).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: aab2496e930dce5ee1ab28eecec94e0e45f03580
+    repository: https://github.com/hapijs/hapi

--- a/statements/CVE-2016-0750/statement.yaml
+++ b/statements/CVE-2016-0750/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2016-0750
+notes:
+- links: []
+  text: The hotrod java client in infinispan before 9.1.0.Final automatically deserializes
+    bytearray message contents in certain events. A malicious user could exploit this
+    flaw by injecting a specially-crafted serialized object to attain remote code
+    execution or conduct other attacks.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f2989a9b7b5ef2d3be690250d9d1bc7b2fa045d7
+    repository: https://github.com/infinispan/infinispan

--- a/statements/CVE-2016-1000236/statement.yaml
+++ b/statements/CVE-2016-1000236/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2016-1000236
+notes:
+- links: []
+  text: Node-cookie-signature before 1.0.6 is affected by a timing attack due to the
+    type of comparison used.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 39791081692e9e14aa62855369e1c7f80fbfd50e
+    repository: https://github.com/tj/node-cookie-signature

--- a/statements/CVE-2016-10173/statement.yaml
+++ b/statements/CVE-2016-10173/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-10173
+notes:
+- links: []
+  text: Directory traversal vulnerability in the minitar before 0.6 and archive-tar-minitar
+    0.5.2 gems for Ruby allows remote attackers to write to arbitrary files via a
+    .. (dot dot) in a TAR archive entry.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 30e62689b614938dc96b4f2cb8e033e72f650670
+    repository: https://github.com/halostatue/minitar

--- a/statements/CVE-2016-10345/statement.yaml
+++ b/statements/CVE-2016-10345/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-10345
+notes:
+- links: []
+  text: In Phusion Passenger before 5.1.0, a known /tmp filename was used during passenger-install-nginx-module
+    execution, which could allow local attackers to gain the privileges of the passenger
+    user.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e5b4b0824d6b648525b4bf63d9fa37e5beeae441
+    repository: https://github.com/phusion/passenger

--- a/statements/CVE-2016-10524/statement.yaml
+++ b/statements/CVE-2016-10524/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2016-10524
+notes:
+- links: []
+  text: i18n-node-angular is a module used to interact between i18n and angular without
+    using additional resources. A REST API endpoint that is used for development in
+    i18n-node-angular before 1.4.0 was not disabled in production environments a malicious
+    user could fill up the server causing a Denial of Service or content injection.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 877720d2d9bb90dc8233706e81ffa03f99fc9dc8
+    repository: https://github.com/oliversalzburg/i18n-node-angular

--- a/statements/CVE-2016-10536/statement.yaml
+++ b/statements/CVE-2016-10536/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2016-10536
+notes:
+- links: []
+  text: engine.io-client is the client for engine.io, the implementation of a transport-based
+    cross-browser/cross-device bi-directional communication layer for Socket.IO. The
+    vulnerability is related to the way that node.js handles the `rejectUnauthorized`
+    setting. If the value is something that evaluates to false, certificate verification
+    will be disabled. This is problematic as engine.io-client 1.6.8 and earlier passes
+    in an object for settings that includes the rejectUnauthorized property, whether
+    it has been set or not. If the value has not been explicitly changed, it will
+    be passed in as `null`, resulting in certificate verification being turned off.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2c55b278a491bf45313ecc0825cf800e2f7ff5c1
+    repository: https://github.com/socketio/engine.io-client

--- a/statements/CVE-2016-10540/statement.yaml
+++ b/statements/CVE-2016-10540/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-10540
+notes:
+- links: []
+  text: Minimatch is a minimal matching utility that works by converting glob expressions
+    into JavaScript `RegExp` objects. The primary function, `minimatch(path, pattern)`
+    in Minimatch 3.0.1 and earlier is vulnerable to ReDoS in the `pattern` parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6944abf9e0694bd22fd9dad293faa40c2bc8a955
+    repository: https://github.com/isaacs/minimatch

--- a/statements/CVE-2016-10544/statement.yaml
+++ b/statements/CVE-2016-10544/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2016-10544
+notes:
+- links: []
+  text: uws is a WebSocket server library. By sending a 256mb websocket message to
+    a uws server instance with permessage-deflate enabled, there is a possibility
+    used compression will shrink said 256mb down to less than 16mb of websocket payload
+    which passes the length check of 16mb payload. This data will then inflate up
+    to 256mb and crash the node process by exceeding V8's maximum string size. This
+    affects uws >=0.10.0 <=0.10.8.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 37deefd01f0875e133ea967122e3a5e421b8fcd9
+    repository: https://github.com/uNetworking/uWebSockets

--- a/statements/CVE-2016-10554/statement.yaml
+++ b/statements/CVE-2016-10554/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2016-10554
+notes:
+- links: []
+  text: sequelize is an Object-relational mapping, or a middleman to convert things
+    from Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server into usable data
+    for NodeJS. Before version 1.7.0-alpha3, sequelize defaulted SQLite to use MySQL
+    backslash escaping, even though SQLite uses Postgres escaping.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c876192aa6ce1f67e22b26a4d175b8478615f42d
+    repository: https://github.com/sequelize/sequelize

--- a/statements/CVE-2016-10556/statement.yaml
+++ b/statements/CVE-2016-10556/statement.yaml
@@ -1,0 +1,19 @@
+vulnerability_id: CVE-2016-10556
+notes:
+- links: []
+  text: 'sequelize is an Object-relational mapping, or a middleman to convert things
+    from Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server into usable data
+    for NodeJS In Postgres, SQLite, and Microsoft SQL Server there is an issue where
+    arrays are treated as strings and improperly escaped. This causes potential SQL
+    injection in sequelize 3.19.3 and earlier, where a malicious user could put `["test",
+    "''); DELETE TestTable WHERE Id = 1 --'')"]` inside of ``` database.query(''SELECT
+    * FROM TestTable WHERE Name IN (:names)'', { replacements: { names: directCopyOfUserInput
+    } }); ``` and cause the SQL statement to become `SELECT Id FROM Table WHERE Name
+    IN (''test'', ''\''); DELETE TestTable WHERE Id = 1 --'')`. In Postgres, MSSQL,
+    and SQLite, the backslash has no special meaning. This causes the the statement
+    to delete whichever Id has a value of 1 in the TestTable table.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 23952a2b020cc3571f090e67dae7feb084e1be71
+    repository: https://github.com/sequelize/sequelize

--- a/statements/CVE-2016-10577/statement.yaml
+++ b/statements/CVE-2016-10577/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2016-10577
+notes:
+- links: []
+  text: ibm_db is an asynchronous/synchronous interface for node.js to IBM DB2 and
+    IBM Informix. ibm_db before 1.0.2 downloads binary resources over HTTP, which
+    leaves it vulnerable to MITM attacks. It may be possible to cause remote code
+    execution (RCE) by swapping out the requested binary with an attacker controlled
+    binary if the attacker is on the network or positioned in between the user and
+    the remote server.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d7e2d4b4cbeb6f067df8bba7d0b2ac5d40fcfc19
+    repository: https://github.com/ibmdb/node-ibm_db

--- a/statements/CVE-2016-10703/statement.yaml
+++ b/statements/CVE-2016-10703/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-10703
+notes:
+- links: []
+  text: A regular expression Denial of Service (DoS) vulnerability in the file lib/ecstatic.js
+    of the ecstatic npm package, before version 2.0.0, allows a remote attacker to
+    overload and crash a server by passing a maliciously crafted string.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 71ce93988ead4b561a8592168c72143907189f01
+    repository: https://github.com/jfhbrook/node-ecstatic

--- a/statements/CVE-2016-2166/statement.yaml
+++ b/statements/CVE-2016-2166/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2016-2166
+notes:
+- links: []
+  text: The (1) proton.reactor.Connector, (2) proton.reactor.Container, and (3) proton.utils.BlockingConnection
+    classes in Apache Qpid Proton before 0.12.1 improperly use an unencrypted connection
+    for an amqps URI scheme when SSL support is unavailable, which might allow man-in-the-middle
+    attackers to obtain sensitive information or modify data via unspecified vectors.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a0585851e1e8ed9678496e38278f4a7554d03636
+    repository: https://github.com/apache/qpid-proton

--- a/statements/CVE-2016-2537/statement.yaml
+++ b/statements/CVE-2016-2537/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-2537
+notes:
+- links: []
+  text: The is-my-json-valid package before 2.12.4 for Node.js has an incorrect exports['utc-millisec']
+    regular expression, which allows remote attackers to cause a denial of service
+    (blocked event loop) via a crafted string.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: eca4beb21e61877d76fdf6bea771f72f39544d9b
+    repository: https://github.com/mafintosh/is-my-json-valid

--- a/statements/CVE-2016-3114/statement.yaml
+++ b/statements/CVE-2016-3114/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2016-3114
+notes:
+- links: []
+  text: Kallithea before 0.3.2 allows remote authenticated users to edit or delete
+    open pull requests or delete comments by leveraging read access.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 460fec61ad108252b7f56575211914e0f82ea6e8
+    repository: https://github.com/NexMirror/Kallithea

--- a/statements/CVE-2016-3693/statement.yaml
+++ b/statements/CVE-2016-3693/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-3693
+notes:
+- links: []
+  text: The Safemode gem before 1.2.4 for Ruby, when initialized with a delegate object
+    that is a Rails controller, allows context-dependent attackers to obtain sensitive
+    information via the inspect method.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0f764a1720a3a68fd2842e21377c8bfad6d7126f
+    repository: https://github.com/svenfuchs/safemode

--- a/statements/CVE-2016-4442/statement.yaml
+++ b/statements/CVE-2016-4442/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-4442
+notes:
+- links: []
+  text: The rack-mini-profiler gem before 0.10.1 for Ruby allows remote attackers
+    to obtain sensitive information about allocated strings and objects by leveraging
+    incorrect ordering of security checks.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4273771d65f1a7411e3ef5843329308d0e2d257c
+    repository: https://github.com/MiniProfiler/rack-mini-profiler

--- a/statements/CVE-2016-4562/statement.yaml
+++ b/statements/CVE-2016-4562/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2016-4562
+notes:
+- links: []
+  text: The DrawDashPolygon function in MagickCore/draw.c in ImageMagick before 6.9.4-0
+    and 7.x before 7.0.1-2 mishandles calculations of certain vertices integer data,
+    which allows remote attackers to cause a denial of service (buffer overflow and
+    application crash) or possibly have unspecified other impact via a crafted file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 726812fa2fa7ce16bcf58f6e115f65427a1c0950
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2016-4563/statement.yaml
+++ b/statements/CVE-2016-4563/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2016-4563
+notes:
+- links: []
+  text: The TraceStrokePolygon function in MagickCore/draw.c in ImageMagick before
+    6.9.4-0 and 7.x before 7.0.1-2 mishandles the relationship between the BezierQuantum
+    value and certain strokes data, which allows remote attackers to cause a denial
+    of service (buffer overflow and application crash) or possibly have unspecified
+    other impact via a crafted file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 726812fa2fa7ce16bcf58f6e115f65427a1c0950
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2016-4564/statement.yaml
+++ b/statements/CVE-2016-4564/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2016-4564
+notes:
+- links: []
+  text: The DrawImage function in MagickCore/draw.c in ImageMagick before 6.9.4-0
+    and 7.x before 7.0.1-2 makes an incorrect function call in attempting to locate
+    the next token, which allows remote attackers to cause a denial of service (buffer
+    overflow and application crash) or possibly have unspecified other impact via
+    a crafted file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 726812fa2fa7ce16bcf58f6e115f65427a1c0950
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2016-4974/statement.yaml
+++ b/statements/CVE-2016-4974/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2016-4974
+notes:
+- links: []
+  text: Apache Qpid AMQP 0-x JMS client before 6.0.4 and JMS (AMQP 1.0) before 0.10.0
+    does not restrict the use of classes available on the classpath, which might allow
+    remote authenticated users with permission to send messages to deserialize arbitrary
+    objects and execute arbitrary code by leveraging a crafted serialized object in
+    a JMS ObjectMessage that is handled by the getObject function.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7e6843e2e1967bfdba477a683353dbf6287d6291
+    repository: https://github.com/apache/qpid-jms-amqp-0-x

--- a/statements/CVE-2016-5104/statement.yaml
+++ b/statements/CVE-2016-5104/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-5104
+notes:
+- links: []
+  text: The socket_create function in common/socket.c in libimobiledevice and libusbmuxd
+    allows remote attackers to bypass intended access restrictions and communicate
+    with services on iOS devices by connecting to an IPv4 TCP socket.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: df1f5c4d70d0c19ad40072f5246ca457e7f9849e
+    repository: https://github.com/libimobiledevice/libimobiledevice

--- a/statements/CVE-2016-5180/statement.yaml
+++ b/statements/CVE-2016-5180/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2016-5180
+notes:
+- links: []
+  text: Heap-based buffer overflow in the ares_create_query function in c-ares 1.x
+    before 1.12.0 allows remote attackers to cause a denial of service (out-of-bounds
+    write) or possibly execute arbitrary code via a hostname with an escaped trailing
+    dot.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 65c71be1cbe587f290432bef2f669ee6cb8ac137
+    repository: https://github.com/c-ares/c-ares

--- a/statements/CVE-2016-5431/statement.yaml
+++ b/statements/CVE-2016-5431/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-5431
+notes:
+- links: []
+  text: The PHP JOSE Library by Gree Inc. before version 2.2.1 is vulnerable to key
+    confusion/algorithm substitution in the JWS component resulting in bypassing the
+    signature verification via crafted tokens.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1cce55e27adf0274193eb1cd74b927a398a3df4b
+    repository: https://github.com/nov/jose-php

--- a/statements/CVE-2016-5697/statement.yaml
+++ b/statements/CVE-2016-5697/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2016-5697
+notes:
+- links: []
+  text: Ruby-saml before 1.3.0 allows attackers to perform XML signature wrapping
+    attacks via unspecified vectors.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a571f52171e6bfd87db59822d1d9e8c38fb3b995
+    repository: https://github.com/onelogin/ruby-saml

--- a/statements/CVE-2016-6298/statement.yaml
+++ b/statements/CVE-2016-6298/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-6298
+notes:
+- links: []
+  text: The _Rsa15 class in the RSA 1.5 algorithm implementation in jwa.py in jwcrypto
+    before 0.3.2 lacks the Random Filling protection mechanism, which makes it easier
+    for remote attackers to obtain cleartext data via a Million Message Attack (MMA).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: eb5be5bd94c8cae1d7f3ba9801377084d8e5a7ba
+    repository: https://github.com/latchset/jwcrypto

--- a/statements/CVE-2016-7528/statement.yaml
+++ b/statements/CVE-2016-7528/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2016-7528
+notes:
+- links: []
+  text: The ReadVIFFImage function in coders/viff.c in ImageMagick allows remote attackers
+    to cause a denial of service (segmentation fault) via a crafted VIFF file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7be16a280014f895a951db4948df316a23dabc09
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2016-9298/statement.yaml
+++ b/statements/CVE-2016-9298/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2016-9298
+notes:
+- links: []
+  text: Heap overflow in the WaveletDenoiseImage function in MagickCore/fx.c in ImageMagick
+    before 6.9.6-4 and 7.x before 7.0.3-6 allows remote attackers to cause a denial
+    of service (crash) via a crafted image.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3cbfb163cff9e5b8cdeace8312e9bfee810ed02b
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2017-0904/statement.yaml
+++ b/statements/CVE-2017-0904/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-0904
+notes:
+- links: []
+  text: The private_address_check ruby gem before 0.4.0 is vulnerable to a bypass
+    due to use of Ruby's Resolv.getaddresses method, which is OS-dependent and should
+    not be relied upon for security measures, such as when used to blacklist private
+    network addresses to prevent server-side request forgery.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 58a0d7fe31de339c0117160567a5b33ad82b46af
+    repository: https://github.com/jtdowney/private_address_check

--- a/statements/CVE-2017-1000188/statement.yaml
+++ b/statements/CVE-2017-1000188/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-1000188
+notes:
+- links: []
+  text: nodejs ejs version older than 2.5.5 is vulnerable to a Cross-site-scripting
+    in the ejs.renderFile() resulting in code injection
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 49264e0037e313a0a3e033450b5c184112516d8f
+    repository: https://github.com/mde/ejs

--- a/statements/CVE-2017-1000189/statement.yaml
+++ b/statements/CVE-2017-1000189/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-1000189
+notes:
+- links: []
+  text: nodejs ejs version older than 2.5.5 is vulnerable to a denial-of-service due
+    to weak input validation in the ejs.renderFile()
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 49264e0037e313a0a3e033450b5c184112516d8f
+    repository: https://github.com/mde/ejs

--- a/statements/CVE-2017-1000228/statement.yaml
+++ b/statements/CVE-2017-1000228/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-1000228
+notes:
+- links: []
+  text: nodejs ejs versions older than 2.5.3 is vulnerable to remote code execution
+    due to weak input validation in ejs.renderFile() function
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3d447c5a335844b25faec04b1132dbc721f9c8f6
+    repository: https://github.com/mde/ejs

--- a/statements/CVE-2017-1000491/statement.yaml
+++ b/statements/CVE-2017-1000491/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-1000491
+notes:
+- links: []
+  text: Shiba markdown live preview app version 1.1.0 is vulnerable to XSS which leads
+    to code execution due to enabled node integration.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e8a65b0f81eb04903eedd29500d7e1bedf249eab
+    repository: https://github.com/rhysd/Shiba

--- a/statements/CVE-2017-1001002/statement.yaml
+++ b/statements/CVE-2017-1001002/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-1001002
+notes:
+- links: []
+  text: math.js before 3.17.0 had an arbitrary code execution in the JavaScript engine.
+    Creating a typed function with JavaScript code in the name could result arbitrary
+    execution.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8d2d48d81b3c233fb64eb2ec1d7a9e1cf6a55a90
+    repository: https://github.com/josdejong/mathjs

--- a/statements/CVE-2017-1001003/statement.yaml
+++ b/statements/CVE-2017-1001003/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-1001003
+notes:
+- links: []
+  text: math.js before 3.17.0 had an issue where private properties such as a constructor
+    could be replaced by using unicode characters when creating an object.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a60f3c8d9dd714244aed7a5569c3dccaa3a4e761
+    repository: https://github.com/josdejong/mathjs

--- a/statements/CVE-2017-1001004/statement.yaml
+++ b/statements/CVE-2017-1001004/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-1001004
+notes:
+- links: []
+  text: typed-function before 0.10.6 had an arbitrary code execution in the JavaScript
+    engine. Creating a typed function with JavaScript code in the name could result
+    arbitrary execution.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6478ef4f2c3f3c2d9f2c820e2db4b4ba3425e6fe
+    repository: https://github.com/josdejong/typed-function

--- a/statements/CVE-2017-1002150/statement.yaml
+++ b/statements/CVE-2017-1002150/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-1002150
+notes:
+- links: []
+  text: python-fedora 0.8.0 and lower is vulnerable to an open redirect resulting
+    in loss of CSRF protection
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b27f38a67573f4c989710c9bfb726dd4c1eeb929
+    repository: https://github.com/fedora-infra/python-fedora

--- a/statements/CVE-2017-11173/statement.yaml
+++ b/statements/CVE-2017-11173/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2017-11173
+notes:
+- links: []
+  text: Missing anchor in generated regex for rack-cors before 0.4.1 allows a malicious
+    third-party site to perform CORS requests. If the configuration were intended
+    to allow only the trusted example.com domain name and not the malicious example.net
+    domain name, then example.com.example.net (as well as example.com-example.net)
+    would be inadvertently allowed.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 42ebe6caa8e85ffa9c8a171bda668ba1acc7a5e6
+    repository: https://github.com/cyu/rack-cors

--- a/statements/CVE-2017-11905/statement.yaml
+++ b/statements/CVE-2017-11905/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2017-11905
+notes:
+- links: []
+  text: ChakraCore and Microsoft Edge in Windows 10 1511, 1607, 1703, 1709, and Windows
+    Server 2016 allows an attacker to execute arbitrary code in the context of the
+    current user, due to how the scripting engine handles objects in memory, aka "Scripting
+    Engine Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-11886,
+    CVE-2017-11889, CVE-2017-11890, CVE-2017-11893, CVE-2017-11894, CVE-2017-11895,
+    CVE-2017-11901, CVE-2017-11903, CVE-2017-11907, CVE-2017-11908, CVE-2017-11909,
+    CVE-2017-11910, CVE-2017-11911, CVE-2017-11912, CVE-2017-11913, CVE-2017-11914,
+    CVE-2017-11916, CVE-2017-11918, and CVE-2017-11930.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d97375c40cfd2b2376a5c4b6cd34098e1e99e1f1
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2017-11910/statement.yaml
+++ b/statements/CVE-2017-11910/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2017-11910
+notes:
+- links: []
+  text: ChakraCore and Windows 10 Gold, 1511, 1607, 1703, 1709, and Windows Server
+    2016 allows an attacker to execute arbitrary code in the context of the current
+    user, due to how the scripting engine handles objects in memory, aka "Scripting
+    Engine Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-11886,
+    CVE-2017-11889, CVE-2017-11890, CVE-2017-11893, CVE-2017-11894, CVE-2017-11895,
+    CVE-2017-11901, CVE-2017-11903, CVE-2017-11905, CVE-2017-11905, CVE-2017-11907,
+    CVE-2017-11908, CVE-2017-11909, CVE-2017-11911, CVE-2017-11912, CVE-2017-11913,
+    CVE-2017-11914, CVE-2017-11916, CVE-2017-11918, and CVE-2017-11930.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 40232a443c6316a58941572b0a4776b0677975ca
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2017-12098/statement.yaml
+++ b/statements/CVE-2017-12098/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2017-12098
+notes:
+- links: []
+  text: An exploitable cross site scripting (XSS) vulnerability exists in the add
+    filter functionality of the rails_admin rails gem version 1.2.0. A specially crafted
+    URL can cause an XSS flaw resulting in an attacker being able to execute arbitrary
+    javascript on the victim's browser. An attacker can phish an authenticated user
+    to trigger this vulnerability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 44f09ed72b5e0e917a5d61bd89c48d97c494b41c
+    repository: https://github.com/sferik/rails_admin

--- a/statements/CVE-2017-12867/statement.yaml
+++ b/statements/CVE-2017-12867/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-12867
+notes:
+- links: []
+  text: The SimpleSAML_Auth_TimeLimitedToken class in SimpleSAMLphp 1.14.14 and earlier
+    allows attackers with access to a secret token to extend its validity period by
+    manipulating the prepended time offset.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 608f24c2d5afd70c2af050785d2b12f878b33c68
+    repository: https://github.com/simplesamlphp/simplesamlphp

--- a/statements/CVE-2017-12871/statement.yaml
+++ b/statements/CVE-2017-12871/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-12871
+notes:
+- links: []
+  text: The aesEncrypt method in lib/SimpleSAML/Utils/Crypto.php in SimpleSAMLphp
+    1.14.x through 1.14.11 makes it easier for context-dependent attackers to bypass
+    the encryption protection mechanism by leveraging use of the first 16 bytes of
+    the secret key as the initialization vector (IV).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 77df6a932d46daa35e364925eb73a175010dc904
+    repository: https://github.com/simplesamlphp/simplesamlphp

--- a/statements/CVE-2017-14619/statement.yaml
+++ b/statements/CVE-2017-14619/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-14619
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in phpMyFAQ through 2.9.8 allows
+    remote attackers to inject arbitrary web script or HTML via the "Title of your
+    FAQ" field in the Configuration Module.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 30b0025e19bd95ba28f4eff4d259671e7bb6bb86
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15051/statement.yaml
+++ b/statements/CVE-2017-15051/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2017-15051
+notes:
+- links: []
+  text: Multiple stored cross-site scripting (XSS) vulnerabilities in TeamPass before
+    2.1.27.9 allow authenticated remote attackers to inject arbitrary web script or
+    HTML via the (1) URL value of an item or (2) user log history. To exploit the
+    vulnerability, the attacker must be first authenticated to the application. For
+    the first one, the attacker has to simply inject XSS code within the URL field
+    of a shared item. For the second one however, the attacker must prepare a payload
+    within its profile, and then ask an administrator to modify its profile. From
+    there, whenever the administrator accesses the log, it can be XSS'ed.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5f16f6bb132138ee04eb1e0debf2bdc7d7b7a15f
+    repository: https://github.com/nilsteampassnet/teampass

--- a/statements/CVE-2017-15052/statement.yaml
+++ b/statements/CVE-2017-15052/statement.yaml
@@ -1,0 +1,15 @@
+vulnerability_id: CVE-2017-15052
+notes:
+- links: []
+  text: TeamPass before 2.1.27.9 does not properly enforce manager access control
+    when requesting users.queries.php. It is then possible for a manager user to delete
+    an arbitrary user (including admin), or modify attributes of any arbitrary user
+    except administrator. To exploit the vulnerability, an authenticated attacker
+    must have the manager rights on the application, then tamper with the requests
+    sent directly, for example by changing the "id" parameter when invoking "delete_user"
+    on users.queries.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8f2d51dd6c24f76e4f259d0df22cff9b275f2dd1
+    repository: https://github.com/nilsteampassnet/TeamPass

--- a/statements/CVE-2017-15053/statement.yaml
+++ b/statements/CVE-2017-15053/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2017-15053
+notes:
+- links: []
+  text: TeamPass before 2.1.27.9 does not properly enforce manager access control
+    when requesting roles.queries.php. It is then possible for a manager user to modify
+    any arbitrary roles within the application, or delete any arbitrary role. To exploit
+    the vulnerability, an authenticated attacker must have the manager rights on the
+    application, then tamper with the requests sent directly, for example by changing
+    the "id" parameter when invoking "delete_role" on roles.queries.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ef32e9c28b6ddc33cee8a25255bc8da54434af3e
+    repository: https://github.com/nilsteampassnet/TeamPass

--- a/statements/CVE-2017-15054/statement.yaml
+++ b/statements/CVE-2017-15054/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2017-15054
+notes:
+- links: []
+  text: An arbitrary file upload vulnerability, present in TeamPass before 2.1.27.9,
+    allows remote authenticated users to upload arbitrary files leading to Remote
+    Command Execution. To exploit this vulnerability, an authenticated attacker has
+    to tamper with parameters of a request to upload.files.php, in order to select
+    the correct branch and be able to upload any arbitrary file. From there, it can
+    simply access the file to execute code on the server.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9811c9d453da4bd1101ff7033250d1fbedf101fc
+    repository: https://github.com/nilsteampassnet/TeamPass

--- a/statements/CVE-2017-15055/statement.yaml
+++ b/statements/CVE-2017-15055/statement.yaml
@@ -1,0 +1,17 @@
+vulnerability_id: CVE-2017-15055
+notes:
+- links: []
+  text: TeamPass before 2.1.27.9 does not properly enforce item access control when
+    requesting items.queries.php. It is then possible to copy any arbitrary item into
+    a directory controlled by the attacker, edit any item within a read-only directory,
+    delete an arbitrary item, delete the file attachments of an arbitrary item, copy
+    the password of an arbitrary item to the copy/paste buffer, access the history
+    of an arbitrary item, and edit attributes of an arbitrary directory. To exploit
+    the vulnerability, an authenticated attacker must tamper with the requests sent
+    directly, for example by changing the "item_id" parameter when invoking "copy_item"
+    on items.queries.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5f16f6bb132138ee04eb1e0debf2bdc7d7b7a15f
+    repository: https://github.com/nilsteampassnet/TeamPass

--- a/statements/CVE-2017-15133/statement.yaml
+++ b/statements/CVE-2017-15133/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-15133
+notes:
+- links: []
+  text: A denial of service flaw was found in miekg-dns before 1.0.4. A remote attacker
+    could use carefully timed TCP packets to block the DNS server from accepting new
+    connections.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 43913f2f4fbd7dcff930b8a809e709591e4dd79e
+    repository: https://github.com/miekg/dns

--- a/statements/CVE-2017-15728/statement.yaml
+++ b/statements/CVE-2017-15728/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-15728
+notes:
+- links: []
+  text: In phpMyFAQ before 2.9.9, there is Stored Cross-site Scripting (XSS) via metaDescription
+    or metaKeywords.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2d2a85b59e058869d7cbcfe2d73fed4a282f2e5b
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15729/statement.yaml
+++ b/statements/CVE-2017-15729/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-15729
+notes:
+- links: []
+  text: In phpMyFAQ before 2.9.9, there is Cross-Site Request Forgery (CSRF) for adding
+    a glossary.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 867618110feb836e168435548d6c2cbb7c65eda3
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15730/statement.yaml
+++ b/statements/CVE-2017-15730/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-15730
+notes:
+- links: []
+  text: In phpMyFAQ before 2.9.9, there is Cross-Site Request Forgery (CSRF) in admin/stat.ratings.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: cce47f94375bb0102ab4f210672231dbb854dd0d
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15731/statement.yaml
+++ b/statements/CVE-2017-15731/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-15731
+notes:
+- links: []
+  text: In phpMyFAQ before 2.9.9, there is Cross-Site Request Forgery (CSRF) in admin/stat.adminlog.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fadb9a70b5f7624a6926b8834d5c6001c210f09c
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15733/statement.yaml
+++ b/statements/CVE-2017-15733/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-15733
+notes:
+- links: []
+  text: In phpMyFAQ before 2.9.9, there is Cross-Site Request Forgery (CSRF) in admin/ajax.attachment.php
+    and admin/att.main.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ef5a66df4bcfacc7573322af33ce10c30e0bb896
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15734/statement.yaml
+++ b/statements/CVE-2017-15734/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-15734
+notes:
+- links: []
+  text: In phpMyFAQ before 2.9.9, there is Cross-Site Request Forgery (CSRF) in admin/stat.main.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fa26c52384b010edaf60c525ae5b040f05da9f77
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15735/statement.yaml
+++ b/statements/CVE-2017-15735/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-15735
+notes:
+- links: []
+  text: In phpMyFAQ before 2.9.9, there is Cross-Site Request Forgery (CSRF) for modifying
+    a glossary.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 867618110feb836e168435548d6c2cbb7c65eda3
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15808/statement.yaml
+++ b/statements/CVE-2017-15808/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2017-15808
+notes:
+- links: []
+  text: In phpMyFaq before 2.9.9, there is CSRF in admin/ajax.config.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a249b4645fb86f6a9fbe5d2344ab1cbdb906b75c
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15809/statement.yaml
+++ b/statements/CVE-2017-15809/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-15809
+notes:
+- links: []
+  text: In phpMyFaq before 2.9.9, there is XSS in admin/tags.main.php via a crafted
+    tag.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: cb648f0d5690b81647dd5c9efe942ebf6cce7da9
+    repository: https://github.com/thorsten/phpMyFAQ

--- a/statements/CVE-2017-15879/statement.yaml
+++ b/statements/CVE-2017-15879/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-15879
+notes:
+- links: []
+  text: CSV Injection (aka Excel Macro Injection or Formula Injection) exists in admin/server/api/download.js
+    and lib/list/getCSVData.js in KeystoneJS before 4.0.0-beta.7 via a value that
+    is mishandled in a CSV export.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4b019b8cfcb7bea6f800609da5d07e8c8abfc80a
+    repository: https://github.com/keystonejs/keystone

--- a/statements/CVE-2017-15928/statement.yaml
+++ b/statements/CVE-2017-15928/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-15928
+notes:
+- links: []
+  text: 'In the Ox gem 2.8.0 for Ruby, the process crashes with a segmentation fault
+    when a crafted input is supplied to parse_obj. NOTE: the vendor has stated "Ox
+    should handle the error more gracefully" but has not confirmed a security implication.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e4565dbc167f0d38c3f93243d7a4fcfc391cbfc8
+    repository: https://github.com/ohler55/ox

--- a/statements/CVE-2017-16003/statement.yaml
+++ b/statements/CVE-2017-16003/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2017-16003
+notes:
+- links: []
+  text: windows-build-tools is a module for installing C++ Build Tools for Windows
+    using npm. windows-build-tools versions below 1.0.0 download resources over HTTP,
+    which leaves it vulnerable to MITM attacks. It may be possible to cause remote
+    code execution (RCE) by swapping out the requested resources with an attacker
+    controlled copy if the attacker is on the network or positioned in between the
+    user and the remote server.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9835d33e68f2cb5e4d148e954bb3ed0221d98e90
+    repository: https://github.com/felixrieseberg/windows-build-tools

--- a/statements/CVE-2017-16008/statement.yaml
+++ b/statements/CVE-2017-16008/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-16008
+notes:
+- links: []
+  text: i18next is a language translation framework. Because of how the interpolation
+    is implemented, making replacements from the dictionary one at a time, untrusted
+    user input can use the name of one of the dictionary keys to inject script into
+    the browser. This affects i18next <=1.10.2.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 34e8e13a2b64708a0aed01092e4dbfd0e5013831
+    repository: https://github.com/i18next/i18next

--- a/statements/CVE-2017-16013/statement.yaml
+++ b/statements/CVE-2017-16013/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-16013
+notes:
+- links: []
+  text: hapi is a web and services application framework. When hapi >= 15.0.0 <= 16.1.0
+    encounters a malformed `accept-encoding` header an uncaught exception is thrown.
+    This may cause hapi to crash or to hang the client connection until the timeout
+    period is reached.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 770cc7bad15122f796d938738b7c05b66d2f4b7f
+    repository: https://github.com/hapijs/hapi

--- a/statements/CVE-2017-16014/statement.yaml
+++ b/statements/CVE-2017-16014/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-16014
+notes:
+- links: []
+  text: Http-proxy is a proxying library. Because of the way errors are handled in
+    versions before 0.7.0, an attacker that forces an error can crash the server,
+    causing a denial of service.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 07c8d2ee6017264c3d4deac9f42ca264a3740b48
+    repository: https://github.com/http-party/node-http-proxy

--- a/statements/CVE-2017-16015/statement.yaml
+++ b/statements/CVE-2017-16015/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-16015
+notes:
+- links: []
+  text: Forms is a library for easily creating HTML forms. Versions before 1.3.0 did
+    not have proper html escaping. This means that if the application did not sanitize
+    html on behalf of forms, use of forms may be vulnerable to cross site scripting
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bc01e534a0ff863dedb2026a50bd03153bbc6a5d
+    repository: https://github.com/caolan/forms

--- a/statements/CVE-2017-16016/statement.yaml
+++ b/statements/CVE-2017-16016/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-16016
+notes:
+- links: []
+  text: 'Sanitize-html is a library for scrubbing html input of malicious values.
+    Versions 1.11.1 and below are vulnerable to cross site scripting (XSS) in certain
+    scenarios: If allowed at least one nonTextTags, the result is a potential XSS
+    vulnerability.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5d205a1005ba0df80e21d8c64a15bb3accdb2403
+    repository: https://github.com/apostrophecms/sanitize-html

--- a/statements/CVE-2017-16025/statement.yaml
+++ b/statements/CVE-2017-16025/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2017-16025
+notes:
+- links: []
+  text: Nes is a websocket extension library for hapi. Hapi is a webserver framework.
+    Versions below and including 6.4.0 have a denial of service vulnerability via
+    an invalid Cookie header. This is only present when websocket authentication is
+    set to `cookie`. Submitting an invalid cookie on the websocket upgrade request
+    will cause the node process to error out.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 249ba1755ed6977fbc208463c87364bf884ad655
+    repository: https://github.com/hapijs/nes

--- a/statements/CVE-2017-16042/statement.yaml
+++ b/statements/CVE-2017-16042/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-16042
+notes:
+- links: []
+  text: Growl adds growl notification support to nodejs. Growl before 1.10.2 does
+    not properly sanitize input before passing it to exec, allowing for arbitrary
+    command execution.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d71177d5331c9de4658aca62e0ac921f178b0669
+    repository: https://github.com/tj/node-growl

--- a/statements/CVE-2017-16136/statement.yaml
+++ b/statements/CVE-2017-16136/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2017-16136
+notes:
+- links: []
+  text: method-override is a module used by the Express.js framework to let you use
+    HTTP verbs such as PUT or DELETE in places where the client doesn't support it.
+    method-override is vulnerable to a regular expression denial of service vulnerability
+    when specially crafted input is passed in to be parsed via the X-HTTP-Method-Override
+    header.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4c58835a61fdf7a8e070d6f8ecd5379a961d0987
+    repository: https://github.com/expressjs/method-override

--- a/statements/CVE-2017-16226/statement.yaml
+++ b/statements/CVE-2017-16226/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-16226
+notes:
+- links: []
+  text: The static-eval module is intended to evaluate statically-analyzable expressions.
+    In affected versions, untrusted user input is able to access the global function
+    constructor, effectively allowing arbitrary code execution.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c06f1b8c0a0cd1cc989c025fbb4c5776fc661c2c
+    repository: https://github.com/browserify/static-eval

--- a/statements/CVE-2017-16244/statement.yaml
+++ b/statements/CVE-2017-16244/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2017-16244
+notes:
+- links: []
+  text: Cross-Site Request Forgery exists in OctoberCMS 1.0.426 (aka Build 426) due
+    to improper validation of CSRF tokens for postback handling, allowing an attacker
+    to successfully take over the victim's account. The attack bypasses a protection
+    mechanism involving X-CSRF headers and CSRF tokens via a certain _handler postback
+    variable.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4a6e0e1e0e2c3facebc17e0db38c5b4d4cb05bd0
+    repository: https://github.com/octobercms/october

--- a/statements/CVE-2017-16613/statement.yaml
+++ b/statements/CVE-2017-16613/statement.yaml
@@ -1,0 +1,15 @@
+vulnerability_id: CVE-2017-16613
+notes:
+- links: []
+  text: 'An issue was discovered in middleware.py in OpenStack Swauth through 1.2.0
+    when used with OpenStack Swift through 2.15.1. The Swift object store and proxy
+    server are saving (unhashed) tokens retrieved from the Swauth middleware authentication
+    mechanism to a log file as part of a GET URI. This allows attackers to bypass
+    authentication by inserting a token into an X-Auth-Token header of a new request.
+    NOTE: github.com/openstack/swauth URLs do not mean that Swauth is maintained by
+    an official OpenStack project team.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 70af7986265a3defea054c46efc82d0698917298
+    repository: https://github.com/openstack-archive/swauth

--- a/statements/CVE-2017-16876/statement.yaml
+++ b/statements/CVE-2017-16876/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-16876
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in the _keyify function in mistune.py
+    in Mistune before 0.8.1 allows remote attackers to inject arbitrary web script
+    or HTML by leveraging failure to escape the "key" argument.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5f06d724bc05580e7f203db2d4a4905fc1127f98
+    repository: https://github.com/lepture/mistune

--- a/statements/CVE-2017-16880/statement.yaml
+++ b/statements/CVE-2017-16880/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-16880
+notes:
+- links: []
+  text: The dump function in Util/TemplateHelper.php in filp whoops before 2.1.13
+    has XSS.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c16791d28d1ca3139e398145f0c6565c523c291a
+    repository: https://github.com/filp/whoops

--- a/statements/CVE-2017-17042/statement.yaml
+++ b/statements/CVE-2017-17042/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-17042
+notes:
+- links: []
+  text: lib/yard/core_ext/file.rb in the server in YARD before 0.9.11 does not block
+    relative paths with an initial ../ sequence, which allows attackers to conduct
+    directory traversal attacks and read arbitrary files.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b0217b3e30dc53d057b1682506333335975e62b4
+    repository: https://github.com/lsegal/yard

--- a/statements/CVE-2017-18367/statement.yaml
+++ b/statements/CVE-2017-18367/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-18367
+notes:
+- links: []
+  text: libseccomp-golang 0.9.0 and earlier incorrectly generates BPFs that OR multiple
+    arguments rather than ANDing them. A process running under a restrictive seccomp
+    filter that specified multiple syscall arguments could bypass intended access
+    restrictions by specifying a single matching argument.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 06e7a29f36a34b8cf419aeb87b979ee508e58f9e
+    repository: https://github.com/seccomp/libseccomp-golang

--- a/statements/CVE-2017-2809/statement.yaml
+++ b/statements/CVE-2017-2809/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-2809
+notes:
+- links: []
+  text: An exploitable vulnerability exists in the yaml loading functionality of ansible-vault
+    before 1.0.5. A specially crafted vault can execute arbitrary python commands
+    resulting in command execution. An attacker can insert python into the vault to
+    trigger this vulnerability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3f8f659ef443ab870bb19f95d43543470168ae04
+    repository: https://github.com/tomoh1r/ansible-vault

--- a/statements/CVE-2017-3204/statement.yaml
+++ b/statements/CVE-2017-3204/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-3204
+notes:
+- links: []
+  text: The Go SSH library (x/crypto/ssh) by default does not verify host keys, facilitating
+    man-in-the-middle attacks. Default behavior changed in commit e4e2799 to require
+    explicitly registering a hostkey verification mechanism.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e4e2799dd7aab89f583e1d898300d96367750991
+    repository: https://github.com/golang/crypto

--- a/statements/CVE-2017-5545/statement.yaml
+++ b/statements/CVE-2017-5545/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-5545
+notes:
+- links: []
+  text: The main function in plistutil.c in libimobiledevice libplist through 1.12
+    allows attackers to obtain sensitive information from process memory or cause
+    a denial of service (buffer over-read) via Apple Property List data that is too
+    short.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7391a506352c009fe044dead7baad9e22dd279ee
+    repository: https://github.com/libimobiledevice/libplist

--- a/statements/CVE-2017-5936/statement.yaml
+++ b/statements/CVE-2017-5936/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-5936
+notes:
+- links: []
+  text: OpenStack Nova-LXD before 13.1.1 uses the wrong name for the veth pairs when
+    applying Neutron security group rules for instances, which allows remote attackers
+    to bypass intended security restrictions.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1b76cefb92081efa1e88cd8f330253f857028bd2
+    repository: https://github.com/openstack-archive/nova-lxd

--- a/statements/CVE-2017-5946/statement.yaml
+++ b/statements/CVE-2017-5946/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-5946
+notes:
+- links: []
+  text: The Zip::File component in the rubyzip gem before 1.2.1 for Ruby has a directory
+    traversal vulnerability. If a site allows uploading of .zip files, an attacker
+    can upload a malicious file that uses "../" pathname substrings to write arbitrary
+    files to the filesystem.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ce4208fdecc2ad079b05d3c49d70fe6ed1d07016
+    repository: https://github.com/rubyzip/rubyzip

--- a/statements/CVE-2017-7540/statement.yaml
+++ b/statements/CVE-2017-7540/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2017-7540
+notes:
+- links: []
+  text: rubygem-safemode, as used in Foreman, versions 1.3.2 and earlier are vulnerable
+    to bypassing safe mode limitations via special Ruby syntax. This can lead to deletion
+    of objects for which the user does not have delete permissions or possibly to
+    privilege escalation.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a019520e441dab1a277fa9aeb41e9266783e9533
+    repository: https://github.com/svenfuchs/safemode

--- a/statements/CVE-2017-7654/statement.yaml
+++ b/statements/CVE-2017-7654/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2017-7654
+notes:
+- links: []
+  text: In Eclipse Mosquitto 1.4.15 and earlier, a Memory Leak vulnerability was found
+    within the Mosquitto Broker. Unauthenticated clients can send crafted CONNECT
+    packets which could cause a denial of service in the Mosquitto Broker.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 51ec5601c2ec523bf2973fdc1eca77335eafb8de
+    repository: https://github.com/eclipse/mosquitto

--- a/statements/CVE-2017-8418/statement.yaml
+++ b/statements/CVE-2017-8418/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2017-8418
+notes:
+- links: []
+  text: RuboCop 0.48.1 and earlier does not use /tmp in safe way, allowing local users
+    to exploit this to tamper with cache files belonging to other users.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: dcb258fabd5f2624c1ea0e1634763094590c09d7
+    repository: https://github.com/rubocop/rubocop

--- a/statements/CVE-2017-8932/statement.yaml
+++ b/statements/CVE-2017-8932/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2017-8932
+notes:
+- links: []
+  text: A bug in the standard library ScalarMult implementation of curve P-256 for
+    amd64 architectures in Go before 1.7.6 and 1.8.x before 1.8.2 causes incorrect
+    results to be generated for specific input points. An adaptive attack can be mounted
+    to progressively extract the scalar input to ScalarMult by submitting crafted
+    points and observing failures to the derive correct output. This leads to a full
+    key recovery attack against static ECDH, as used in popular JWT libraries.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9294fa2749ffee7edbbb817a0ef9fe633136fa9c
+    repository: https://github.com/golang/go

--- a/statements/CVE-2018-1000119/statement.yaml
+++ b/statements/CVE-2018-1000119/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2018-1000119
+notes:
+- links: []
+  text: Sinatra rack-protection versions 1.5.4 and 2.0.0.rc3 and earlier contains
+    a timing attack vulnerability in the CSRF token checking that can result in signatures
+    can be exposed. This attack appear to be exploitable via network connectivity
+    to the ruby application. This vulnerability appears to have been fixed in 1.5.5
+    and 2.0.0.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8aa6c42ef724f93ae309fb7c5668e19ad547eceb
+    repository: https://github.com/sinatra/sinatra

--- a/statements/CVE-2018-1000538/statement.yaml
+++ b/statements/CVE-2018-1000538/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2018-1000538
+notes:
+- links: []
+  text: Minio Inc. Minio S3 server version prior to RELEASE.2018-05-16T23-35-33Z contains
+    a Allocation of Memory Without Limits or Throttling (similar to CWE-774) vulnerability
+    in write-to-RAM that can result in Denial of Service. This attack appear to be
+    exploitable via Sending V4-(pre)signed requests with large bodies . This vulnerability
+    appears to have been fixed in after commit 9c8b7306f55f2c8c0a5c7cea9a8db9d34be8faa7.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9c8b7306f55f2c8c0a5c7cea9a8db9d34be8faa7
+    repository: https://github.com/minio/minio

--- a/statements/CVE-2018-1000888/statement.yaml
+++ b/statements/CVE-2018-1000888/statement.yaml
@@ -1,0 +1,19 @@
+vulnerability_id: CVE-2018-1000888
+notes:
+- links: []
+  text: PEAR Archive_Tar version 1.4.3 and earlier contains a CWE-502, CWE-915 vulnerability
+    in the Archive_Tar class. There are several file operations with `$v_header['filename']`
+    as parameter (such as file_exists, is_file, is_dir, etc). When extract is called
+    without a specific prefix path, we can trigger unserialization by crafting a tar
+    file with `phar://[path_to_malicious_phar_file]` as path. Object injection can
+    be used to trigger destruct in the loaded PHP classes, e.g. the Archive_Tar class
+    itself. With Archive_Tar object injection, arbitrary file deletion can occur because
+    `@unlink($this->_temp_tarname)` is called. If another class with useful gadget
+    is loaded, it may possible to cause remote code execution that can result in files
+    being deleted or possibly modified. This vulnerability appears to have been fixed
+    in 1.4.4.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 59ace120ac5ceb5f0d36e40e48e1884de1badf76
+    repository: https://github.com/pear/Archive_Tar

--- a/statements/CVE-2018-1002207/statement.yaml
+++ b/statements/CVE-2018-1002207/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-1002207
+notes:
+- links: []
+  text: mholt/archiver golang package before e4ef56d48eb029648b0e895bb0b6a393ef0829c3
+    is vulnerable to directory traversal, allowing attackers to write to arbitrary
+    files via a ../ (dot dot slash) in an archive entry that is mishandled during
+    extraction. This vulnerability is also known as 'Zip-Slip'.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e4ef56d48eb029648b0e895bb0b6a393ef0829c3
+    repository: https://github.com/mholt/archiver

--- a/statements/CVE-2018-1002208/statement.yaml
+++ b/statements/CVE-2018-1002208/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-1002208
+notes:
+- links: []
+  text: SharpZipLib before 1.0 RC1 is vulnerable to directory traversal, allowing
+    attackers to write to arbitrary files via a ../ (dot dot slash) in a Zip archive
+    entry that is mishandled during extraction. This vulnerability is also known as
+    'Zip-Slip'.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5376c2daf1c0e0665398dee765af2047e43146ca
+    repository: https://github.com/icsharpcode/SharpZipLib

--- a/statements/CVE-2018-10092/statement.yaml
+++ b/statements/CVE-2018-10092/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-10092
+notes:
+- links: []
+  text: The admin panel in Dolibarr before 7.0.2 might allow remote attackers to execute
+    arbitrary commands by leveraging support for updating the antivirus command and
+    parameters used to scan file uploads.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5d121b2d3ae2a95abebc9dc31e4782cbc61a1f39
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-10094/statement.yaml
+++ b/statements/CVE-2018-10094/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-10094
+notes:
+- links: []
+  text: SQL injection vulnerability in Dolibarr before 7.0.2 allows remote attackers
+    to execute arbitrary SQL commands via vectors involving integer parameters without
+    quotes.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7ade4e37f24d6859987bb9f6232f604325633fdd
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-10095/statement.yaml
+++ b/statements/CVE-2018-10095/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-10095
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in Dolibarr before 7.0.2 allows remote
+    attackers to inject arbitrary web script or HTML via the foruserlogin parameter
+    to adherents/cartes/carte.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1dc466e1fb687cfe647de4af891720419823ed56
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-10188/statement.yaml
+++ b/statements/CVE-2018-10188/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-10188
+notes:
+- links: []
+  text: phpMyAdmin 4.8.0 before 4.8.0-1 has CSRF, allowing an attacker to execute
+    arbitrary SQL statements, related to js/db_operations.js, js/tbl_operations.js,
+    libraries/classes/Operations.php, and sql.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c6dd6b56e236a3aff953cee4135ecaa67130e641
+    repository: https://github.com/phpmyadmin/phpmyadmin

--- a/statements/CVE-2018-10366/statement.yaml
+++ b/statements/CVE-2018-10366/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-10366
+notes:
+- links: []
+  text: An issue was discovered in the Users (aka Front-end user management) plugin
+    1.4.5 for October CMS. XSS exists in the name field.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 098c2bc907443d67e9e18645f850e3de42941d20
+    repository: https://github.com/rainlab/user-plugin

--- a/statements/CVE-2018-1098/statement.yaml
+++ b/statements/CVE-2018-1098/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2018-1098
+notes:
+- links: []
+  text: A cross-site request forgery flaw was found in etcd 3.3.1 and earlier. An
+    attacker can set up a website that tries to send a POST request to the etcd server
+    and modify a key. Adding a key is done with PUT so it is theoretically safe (can't
+    PUT from an HTML form or such) but POST allows creating in-order keys that an
+    attacker can send.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a7e5790c82039945639798ae9a3289fe787f5e56
+    repository: https://github.com/etcd-io/etcd

--- a/statements/CVE-2018-1099/statement.yaml
+++ b/statements/CVE-2018-1099/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-1099
+notes:
+- links: []
+  text: DNS rebinding vulnerability found in etcd 3.3.1 and earlier. An attacker can
+    control his DNS records to direct to localhost, and trick the browser into sending
+    requests to localhost (or any other address).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a7e5790c82039945639798ae9a3289fe787f5e56
+    repository: https://github.com/etcd-io/etcd

--- a/statements/CVE-2018-11093/statement.yaml
+++ b/statements/CVE-2018-11093/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-11093
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in the Link package for CKEditor
+    5 before 10.0.1 allows remote attackers to inject arbitrary web script through
+    a crafted href attribute of a link (A) element.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8cb782eceba10fc481e4021cb5d25b2a85d1b04e
+    repository: https://github.com/ckeditor/ckeditor5-link

--- a/statements/CVE-2018-11798/statement.yaml
+++ b/statements/CVE-2018-11798/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-11798
+notes:
+- links: []
+  text: The Apache Thrift Node.js static web server in versions 0.9.2 through 0.11.0
+    have been determined to contain a security vulnerability in which a remote user
+    has the ability to access files outside the set webservers docroot path.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2a2b72f6c8aef200ecee4984f011e06052288ff2
+    repository: https://github.com/apache/thrift

--- a/statements/CVE-2018-12043/statement.yaml
+++ b/statements/CVE-2018-12043/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-12043
+notes:
+- links: []
+  text: content/content.blueprintspages.php in Symphony 2.7.6 has XSS via the pages
+    content page.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1ace6b31867cc83267b3550686271c9c65ac3ec0
+    repository: https://github.com/symphonycms/symphonycms

--- a/statements/CVE-2018-12615/statement.yaml
+++ b/statements/CVE-2018-12615/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-12615
+notes:
+- links: []
+  text: An issue was discovered in switchGroup() in agent/ExecHelper/ExecHelperMain.cpp
+    in Phusion Passenger before 5.3.2. The set of groups (gidset) is not set correctly,
+    leaving it up to randomness (i.e., uninitialized memory) which supplementary groups
+    are actually being set while lowering privileges.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4e97fdb86d0a0141ec9a052c6e691fcd07bb45c8
+    repository: https://github.com/phusion/passenger

--- a/statements/CVE-2018-12976/statement.yaml
+++ b/statements/CVE-2018-12976/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-12976
+notes:
+- links: []
+  text: In Go Doc Dot Org (gddo) through 2018-06-27, an attacker could use specially
+    crafted <go-import> tags in packages being fetched by gddo to cause a directory
+    traversal and remote code execution.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: daffe1f90ec57f8ed69464f9094753fc6452e983
+    repository: https://github.com/golang/gddo

--- a/statements/CVE-2018-13447/statement.yaml
+++ b/statements/CVE-2018-13447/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-13447
+notes:
+- links: []
+  text: SQL injection vulnerability in product/card.php in Dolibarr ERP/CRM version
+    7.0.3 allows remote attackers to execute arbitrary SQL commands via the statut
+    parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 36402c22eef49d60edd73a2f312f8e28fe0bd1cb
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-13448/statement.yaml
+++ b/statements/CVE-2018-13448/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-13448
+notes:
+- links: []
+  text: SQL injection vulnerability in product/card.php in Dolibarr ERP/CRM version
+    7.0.3 allows remote attackers to execute arbitrary SQL commands via the country_id
+    parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 36402c22eef49d60edd73a2f312f8e28fe0bd1cb
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-13449/statement.yaml
+++ b/statements/CVE-2018-13449/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-13449
+notes:
+- links: []
+  text: SQL injection vulnerability in product/card.php in Dolibarr ERP/CRM version
+    7.0.3 allows remote attackers to execute arbitrary SQL commands via the statut_buy
+    parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 36402c22eef49d60edd73a2f312f8e28fe0bd1cb
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-13450/statement.yaml
+++ b/statements/CVE-2018-13450/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-13450
+notes:
+- links: []
+  text: SQL injection vulnerability in product/card.php in Dolibarr ERP/CRM version
+    7.0.3 allows remote attackers to execute arbitrary SQL commands via the status_batch
+    parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 36402c22eef49d60edd73a2f312f8e28fe0bd1cb
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-13797/statement.yaml
+++ b/statements/CVE-2018-13797/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-13797
+notes:
+- links: []
+  text: The macaddress module before 0.2.9 for Node.js is prone to an arbitrary command
+    injection flaw, due to allowing unsanitized input to an exec (rather than execFile)
+    call.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 358fd594adb196a86b94ac9c691f69fe5dad2332
+    repository: https://github.com/scravy/node-macaddress

--- a/statements/CVE-2018-14041/statement.yaml
+++ b/statements/CVE-2018-14041/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-14041
+notes:
+- links: []
+  text: In Bootstrap before 4.1.2, XSS is possible in the data-target property of
+    scrollspy.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: cc61edfa8af7b5ec9d4888c59bf94377e499b78b
+    repository: https://github.com/twbs/bootstrap

--- a/statements/CVE-2018-14840/statement.yaml
+++ b/statements/CVE-2018-14840/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-14840
+notes:
+- links: []
+  text: uploads/.htaccess in Subrion CMS 4.2.1 allows XSS because it does not block
+    .html file uploads (but does block, for example, .htm file uploads).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b12e287d3814c0f2d0b1892f95fc0190972d2ba5
+    repository: https://github.com/intelliants/subrion

--- a/statements/CVE-2018-15178/statement.yaml
+++ b/statements/CVE-2018-15178/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-15178
+notes:
+- links: []
+  text: Open redirect vulnerability in Gogs before 0.12 allows remote attackers to
+    redirect users to arbitrary websites and conduct phishing attacks via an initial
+    /\ substring in the user/login redirect_to parameter, related to the function
+    isValidRedirect in routes/user/auth.go.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1f247cf8139cb483276cd8dd06385a800ce9d4b2
+    repository: https://github.com/gogs/gogs

--- a/statements/CVE-2018-16329/statement.yaml
+++ b/statements/CVE-2018-16329/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-16329
+notes:
+- links: []
+  text: In ImageMagick before 7.0.8-8, a NULL pointer dereference exists in the GetMagickProperty
+    function in MagickCore/property.c.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2c75f301d9ac84f91071393b02d8c88c8341c91c
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2018-16472/statement.yaml
+++ b/statements/CVE-2018-16472/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-16472
+notes:
+- links: []
+  text: A prototype pollution attack in cached-path-relative versions <=1.0.1 allows
+    an attacker to inject properties on Object.prototype which are then inherited
+    by all the JS objects through the prototype chain causing a DoS attack.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a43cffec84ed0e9eceecb43b534b6937a8028fc0
+    repository: https://github.com/ashaffer/cached-path-relative

--- a/statements/CVE-2018-16492/statement.yaml
+++ b/statements/CVE-2018-16492/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-16492
+notes:
+- links: []
+  text: A prototype pollution vulnerability was found in module extend <2.0.2, ~<3.0.2
+    that allows an attacker to inject arbitrary properties onto Object.prototype.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0e68e71d93507fcc391e398bc84abd0666b28190
+    repository: https://github.com/justmoon/node-extend

--- a/statements/CVE-2018-17104/statement.yaml
+++ b/statements/CVE-2018-17104/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-17104
+notes:
+- links: []
+  text: An issue was discovered in Microweber 1.0.7. There is a CSRF attack (against
+    the admin user) that can add an administrative account via api/save_user.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 982ea9d5efb7d2306a05644ebc3469dadb33767e
+    repository: https://github.com/microweber/microweber

--- a/statements/CVE-2018-17419/statement.yaml
+++ b/statements/CVE-2018-17419/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-17419
+notes:
+- links: []
+  text: An issue was discovered in setTA in scan_rr.go in the Miek Gieben DNS library
+    before 1.0.10 for Go. A dns.ParseZone() parsing error causes a segmentation violation,
+    leading to denial of service.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 501e858f679edecd4a38a86317ce50271014a80d
+    repository: https://github.com/miekg/dns

--- a/statements/CVE-2018-18476/statement.yaml
+++ b/statements/CVE-2018-18476/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-18476
+notes:
+- links: []
+  text: mysql-binuuid-rails 1.1.0 and earlier allows SQL Injection because it removes
+    default string escaping for affected database columns.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9ae920951b46ff0163b16c55d744e89acb1036d4
+    repository: https://github.com/nedap/mysql-binuuid-rails

--- a/statements/CVE-2018-19048/statement.yaml
+++ b/statements/CVE-2018-19048/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-19048
+notes:
+- links: []
+  text: Simditor through 2.3.21 allows DOM XSS via an onload attribute within a malformed
+    SVG element.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ef01a643cbb7f8163535d6bfb71135f80ec6a6fd
+    repository: https://github.com/mycolorway/simditor

--- a/statements/CVE-2018-1999024/statement.yaml
+++ b/statements/CVE-2018-1999024/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2018-1999024
+notes:
+- links: []
+  text: MathJax version prior to version 2.7.4 contains a Cross Site Scripting (XSS)
+    vulnerability in the \unicode{} macro that can result in Potentially untrusted
+    Javascript running within a web browser. This attack appear to be exploitable
+    via The victim must view a page where untrusted content is processed using Mathjax.
+    This vulnerability appears to have been fixed in 2.7.4 and later.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a55da396c18cafb767a26aa9ad96f6f4199852f1
+    repository: https://github.com/mathjax/MathJax

--- a/statements/CVE-2018-19992/statement.yaml
+++ b/statements/CVE-2018-19992/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-19992
+notes:
+- links: []
+  text: A stored cross-site scripting (XSS) vulnerability in Dolibarr 8.0.2 allows
+    remote authenticated users to inject arbitrary web script or HTML via the "address"
+    (POST) or "town" (POST) parameter to adherents/type.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0f06e39d23636bd1e4039ac61a743c79725c798b
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-19993/statement.yaml
+++ b/statements/CVE-2018-19993/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-19993
+notes:
+- links: []
+  text: A reflected cross-site scripting (XSS) vulnerability in Dolibarr 8.0.2 allows
+    remote attackers to inject arbitrary web script or HTML via the transphrase parameter
+    to public/notice.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fc3fcc5455d9a610b85723e89e8be43a41ad1378
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-19994/statement.yaml
+++ b/statements/CVE-2018-19994/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-19994
+notes:
+- links: []
+  text: An error-based SQL injection vulnerability in product/card.php in Dolibarr
+    version 8.0.2 allows remote authenticated users to execute arbitrary SQL commands
+    via the desiredstock parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 850b939ffd2c7a4443649331b923d5e0da2d6446
+    repository: https://github.com/Dolibarr/dolibarr

--- a/statements/CVE-2018-20028/statement.yaml
+++ b/statements/CVE-2018-20028/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-20028
+notes:
+- links: []
+  text: Contao 3.x before 3.5.37, 4.4.x before 4.4.31 and 4.6.x before 4.6.11 has
+    Incorrect Access Control.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bbe5fe1d385cd1195670e2d6b972272133443c59
+    repository: https://github.com/contao/contao

--- a/statements/CVE-2018-20677/statement.yaml
+++ b/statements/CVE-2018-20677/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-20677
+notes:
+- links: []
+  text: In Bootstrap before 3.4.0, XSS is possible in the affix configuration target
+    property.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2a5ba23ce8f041f3548317acc992ed8a736b609d
+    repository: https://github.com/twbs/bootstrap

--- a/statements/CVE-2018-20801/statement.yaml
+++ b/statements/CVE-2018-20801/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-20801
+notes:
+- links: []
+  text: In js/parts/SvgRenderer.js in Highcharts JS before 6.1.0, the use of backtracking
+    regular expressions permitted an attacker to conduct a denial of service attack
+    against the SVGRenderer component, aka ReDoS.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7c547e1e0f5e4379f94396efd559a566668c0dfa
+    repository: https://github.com/highcharts/highcharts

--- a/statements/CVE-2018-3712/statement.yaml
+++ b/statements/CVE-2018-3712/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-3712
+notes:
+- links: []
+  text: serve node module before 6.4.9 suffers from a Path Traversal vulnerability
+    due to not handling %2e (.) and %2f (/) and allowing them in paths, which allows
+    a malicious user to view the contents of any directory with known path.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6adad6881c61991da61ebc857857c53409544575
+    repository: https://github.com/vercel/serve

--- a/statements/CVE-2018-3715/statement.yaml
+++ b/statements/CVE-2018-3715/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-3715
+notes:
+- links: []
+  text: glance node module before 3.0.4 suffers from a Path Traversal vulnerability
+    due to lack of validation of path passed to it, which allows a malicious user
+    to read content of any file with known path.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8cfd88e44ebd3f07e3a2eaf376a3e758b6c4ca19
+    repository: https://github.com/jarofghosts/glance

--- a/statements/CVE-2018-3721/statement.yaml
+++ b/statements/CVE-2018-3721/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-3721
+notes:
+- links: []
+  text: lodash node module before 4.17.5 suffers from a Modification of Assumed-Immutable
+    Data (MAID) vulnerability via defaultsDeep, merge, and mergeWith functions, which
+    allows a malicious user to modify the prototype of "Object" via __proto__, causing
+    the addition or modification of an existing property that will exist on all objects.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a
+    repository: https://github.com/lodash/lodash

--- a/statements/CVE-2018-3726/statement.yaml
+++ b/statements/CVE-2018-3726/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-3726
+notes:
+- links: []
+  text: crud-file-server node module before 0.8.0 suffers from a Cross-Site Scripting
+    vulnerability to a lack of validation of file names.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4155bfe068bf211b49a0b3ffd06e78cbaf1b40fa
+    repository: https://github.com/omphalos/crud-file-server

--- a/statements/CVE-2018-3732/statement.yaml
+++ b/statements/CVE-2018-3732/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-3732
+notes:
+- links: []
+  text: resolve-path node module before 1.4.0 suffers from a Path Traversal vulnerability
+    due to lack of validation of paths with certain special characters, which allows
+    a malicious user to read content of any file with known path.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: fe5b8052cafd35fcdafe9210e100e9050b37d2a0
+    repository: https://github.com/pillarjs/resolve-path

--- a/statements/CVE-2018-3733/statement.yaml
+++ b/statements/CVE-2018-3733/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-3733
+notes:
+- links: []
+  text: crud-file-server node module before 0.9.0 suffers from a Path Traversal vulnerability
+    due to incorrect validation of url, which allows a malicious user to read content
+    of any file with known path.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4fc3b404f718abb789f4ce4272c39c7a138c7a82
+    repository: https://github.com/omphalos/crud-file-server

--- a/statements/CVE-2018-3740/statement.yaml
+++ b/statements/CVE-2018-3740/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-3740
+notes:
+- links: []
+  text: A specially crafted HTML fragment can cause Sanitize gem for Ruby to allow
+    non-whitelisted attributes to be used on a whitelisted HTML element.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 01629a162e448a83d901456d0ba8b65f3b03d46e
+    repository: https://github.com/rgrove/sanitize

--- a/statements/CVE-2018-3741/statement.yaml
+++ b/statements/CVE-2018-3741/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2018-3741
+notes:
+- links: []
+  text: There is a possible XSS vulnerability in all rails-html-sanitizer gem versions
+    below 1.0.4 for Ruby. The gem allows non-whitelisted attributes to be present
+    in sanitized output when input with specially-crafted HTML fragments, and these
+    attributes can lead to an XSS attack on target applications. This issue is similar
+    to CVE-2018-8048 in Loofah. All users running an affected release should either
+    upgrade or use one of the workarounds immediately.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f3ba1a839a35f2ba7f941c15e239a1cb379d56ae
+    repository: https://github.com/rails/rails-html-sanitizer

--- a/statements/CVE-2018-3750/statement.yaml
+++ b/statements/CVE-2018-3750/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-3750
+notes:
+- links: []
+  text: The utilities function in all versions <= 0.5.0 of the deep-extend node module
+    can be tricked into modifying the prototype of Object when the attacker can control
+    part of the structure passed to this function. This can let an attacker add or
+    modify existing properties that will exist on all objects.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9423fae877e2ab6b4aecc4db79a0ed63039d4703
+    repository: https://github.com/unclechu/node-deep-extend

--- a/statements/CVE-2018-3759/statement.yaml
+++ b/statements/CVE-2018-3759/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-3759
+notes:
+- links: []
+  text: private_address_check ruby gem before 0.5.0 is vulnerable to a time-of-check
+    time-of-use (TOCTOU) race condition due to the address the socket uses not being
+    checked. DNS entries with a TTL of 0 can trigger this case where the initial resolution
+    is a public address but the subsequent resolution is a private address.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4068228187db87fea7577f7020099399772bb147
+    repository: https://github.com/jtdowney/private_address_check

--- a/statements/CVE-2018-3769/statement.yaml
+++ b/statements/CVE-2018-3769/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-3769
+notes:
+- links: []
+  text: ruby-grape ruby gem suffers from a cross-site scripting (XSS) vulnerability
+    via "format" parameter.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6876b71efc7b03f7ce1be3f075eaa4e7e6de19af
+    repository: https://github.com/ruby-grape/grape

--- a/statements/CVE-2018-3774/statement.yaml
+++ b/statements/CVE-2018-3774/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-3774
+notes:
+- links: []
+  text: Incorrect parsing in url-parse <1.4.3 returns wrong hostname which leads to
+    multiple vulnerabilities such as SSRF, Open Redirect, Bypass Authentication Protocol.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 53b1794e54d0711ceb52505e0f74145270570d5a
+    repository: https://github.com/unshiftio/url-parse

--- a/statements/CVE-2018-3778/statement.yaml
+++ b/statements/CVE-2018-3778/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-3778
+notes:
+- links: []
+  text: Improper authorization in aedes version <0.35.0 will publish a LWT in a channel
+    when a client is not authorized.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ffbc1702bb24b596afbb96407cc6db234a4044a8
+    repository: https://github.com/moscajs/aedes

--- a/statements/CVE-2018-3786/statement.yaml
+++ b/statements/CVE-2018-3786/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-3786
+notes:
+- links: []
+  text: A command injection vulnerability in egg-scripts <v2.8.1 allows arbitrary
+    shell command execution through a maliciously crafted command line argument.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b98fd03d1e3aaed68004b881f0b3d42fe47341dd
+    repository: https://github.com/eggjs/egg-scripts

--- a/statements/CVE-2018-6333/statement.yaml
+++ b/statements/CVE-2018-6333/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2018-6333
+notes:
+- links: []
+  text: The hhvm-attach deep link handler in Nuclide did not properly sanitize the
+    provided hostname parameter when rendering. As a result, a malicious URL could
+    be used to render HTML and other content inside of the editor's context, which
+    could potentially be chained to lead to code execution. This issue affected Nuclide
+    prior to v0.290.0.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 65f6bbd683404be1bb569b8d1be84b5d4c74a324
+    repository: https://github.com/facebookarchive/nuclide

--- a/statements/CVE-2018-7260/statement.yaml
+++ b/statements/CVE-2018-7260/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-7260
+notes:
+- links: []
+  text: Cross-site scripting (XSS) vulnerability in db_central_columns.php in phpMyAdmin
+    before 4.7.8 allows remote authenticated users to inject arbitrary web script
+    or HTML via a crafted URL.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d2886a3e8745e8845633ae8a0054b5ee4d8babd5
+    repository: https://github.com/phpmyadmin/composer

--- a/statements/CVE-2018-7560/statement.yaml
+++ b/statements/CVE-2018-7560/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-7560
+notes:
+- links: []
+  text: index.js in the Anton Myshenin aws-lambda-multipart-parser NPM package before
+    0.1.2 has a Regular Expression Denial of Service (ReDoS) issue via a crafted multipart/form-data
+    boundary string.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 56ccb03af4dddebc2b2defb348b6558783d5757e
+    repository: https://github.com/myshenin/aws-lambda-multipart-parser

--- a/statements/CVE-2018-7651/statement.yaml
+++ b/statements/CVE-2018-7651/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-7651
+notes:
+- links: []
+  text: index.js in the ssri module before 5.2.2 for Node.js is prone to a regular
+    expression denial of service vulnerability in strict mode functionality via a
+    long base64 hash string.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d0ebcdc22cb5c8f47f89716d08b3518b2485d65d
+    repository: https://github.com/zkat/ssri

--- a/statements/CVE-2018-8128/statement.yaml
+++ b/statements/CVE-2018-8128/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2018-8128
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the scripting
+    engine handles objects in memory in Microsoft Edge, aka "Scripting Engine Memory
+    Corruption Vulnerability." This affects Microsoft Edge, ChakraCore. This CVE ID
+    is unique from CVE-2018-0945, CVE-2018-0946, CVE-2018-0951, CVE-2018-0953, CVE-2018-0954,
+    CVE-2018-0955, CVE-2018-1022, CVE-2018-8114, CVE-2018-8122, CVE-2018-8137, CVE-2018-8139.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 23848b1272067625ab50115c6f30a0b177c633ba
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2018-8177/statement.yaml
+++ b/statements/CVE-2018-8177/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-8177
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka "Chakra Scripting Engine
+    Memory Corruption Vulnerability." This affects ChakraCore. This CVE ID is unique
+    from CVE-2018-0943, CVE-2018-8130, CVE-2018-8133, CVE-2018-8145.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: eb4b00bcd61a56d5ac66f4155870cba3178d3273
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2018-8178/statement.yaml
+++ b/statements/CVE-2018-8178/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2018-8178
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that Microsoft browsers
+    access objects in memory, aka "Microsoft Browser Memory Corruption Vulnerability."
+    This affects ChakraCore, Internet Explorer 11, Microsoft Edge.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c8f723d99c484c3a31df2187cdd2893ac27506a3
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2018-8381/statement.yaml
+++ b/statements/CVE-2018-8381/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2018-8381
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka "Chakra Scripting Engine
+    Memory Corruption Vulnerability." This affects Microsoft Edge, ChakraCore. This
+    CVE ID is unique from CVE-2018-8266, CVE-2018-8380, CVE-2018-8384.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1b77d559416116f9719febb7dee3354150277588
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2018-8390/statement.yaml
+++ b/statements/CVE-2018-8390/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2018-8390
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the ChakraCore
+    scripting engine handles objects in memory, aka "Scripting Engine Memory Corruption
+    Vulnerability." This affects Microsoft Edge, ChakraCore. This CVE ID is unique
+    from CVE-2018-8353, CVE-2018-8355, CVE-2018-8359, CVE-2018-8371, CVE-2018-8372,
+    CVE-2018-8373, CVE-2018-8385, CVE-2018-8389.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 63ae30a750a4a0b2a2eb61a35dd3d2fc10104a90
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2018-9206/statement.yaml
+++ b/statements/CVE-2018-9206/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2018-9206
+notes:
+- links: []
+  text: Unauthenticated arbitrary file upload vulnerability in Blueimp jQuery-File-Upload
+    <= v9.22.0
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: aeb47e51c67df8a504b7726595576c1c66b5dc2f
+    repository: https://github.com/blueimp/jQuery-File-Upload

--- a/statements/CVE-2019-0911/statement.yaml
+++ b/statements/CVE-2019-0911/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-0911
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way the scripting engine
+    handles objects in memory in Microsoft browsers, aka 'Scripting Engine Memory
+    Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0884, CVE-2019-0918.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a2deba5e1850782014a2a34678464b251e448337
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-0912/statement.yaml
+++ b/statements/CVE-2019-0912/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-0912
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0913, CVE-2019-0914,
+    CVE-2019-0915, CVE-2019-0916, CVE-2019-0917, CVE-2019-0922, CVE-2019-0923, CVE-2019-0924,
+    CVE-2019-0925, CVE-2019-0927, CVE-2019-0933, CVE-2019-0937.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 936a5af1c07e0fdec9aab85c05339dabe4aaeeb1
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-0917/statement.yaml
+++ b/statements/CVE-2019-0917/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-0917
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0912, CVE-2019-0913,
+    CVE-2019-0914, CVE-2019-0915, CVE-2019-0916, CVE-2019-0922, CVE-2019-0923, CVE-2019-0924,
+    CVE-2019-0925, CVE-2019-0927, CVE-2019-0933, CVE-2019-0937.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b5f8fad1b00087bd0a24cc173c2dfedc4f8aee33
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-0922/statement.yaml
+++ b/statements/CVE-2019-0922/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-0922
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0912, CVE-2019-0913,
+    CVE-2019-0914, CVE-2019-0915, CVE-2019-0916, CVE-2019-0917, CVE-2019-0923, CVE-2019-0924,
+    CVE-2019-0925, CVE-2019-0927, CVE-2019-0933, CVE-2019-0937.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a9ab1aae31078e80593b9227db11d316c2239ef3
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-0924/statement.yaml
+++ b/statements/CVE-2019-0924/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-0924
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0912, CVE-2019-0913,
+    CVE-2019-0914, CVE-2019-0915, CVE-2019-0916, CVE-2019-0917, CVE-2019-0922, CVE-2019-0923,
+    CVE-2019-0925, CVE-2019-0927, CVE-2019-0933, CVE-2019-0937.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6615113a09c0618ecc10e5680ffb978bf665641f
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-0925/statement.yaml
+++ b/statements/CVE-2019-0925/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-0925
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0912, CVE-2019-0913,
+    CVE-2019-0914, CVE-2019-0915, CVE-2019-0916, CVE-2019-0917, CVE-2019-0922, CVE-2019-0923,
+    CVE-2019-0924, CVE-2019-0927, CVE-2019-0933, CVE-2019-0937.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 32ca10f3955f2a3ca56c6671c721b1264eca06b8
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-0933/statement.yaml
+++ b/statements/CVE-2019-0933/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-0933
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0912, CVE-2019-0913,
+    CVE-2019-0914, CVE-2019-0915, CVE-2019-0916, CVE-2019-0917, CVE-2019-0922, CVE-2019-0923,
+    CVE-2019-0924, CVE-2019-0925, CVE-2019-0927, CVE-2019-0937.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 1a550c67b33b27675c0553152cabd09e4ffe3abf
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-1000005/statement.yaml
+++ b/statements/CVE-2019-1000005/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2019-1000005
+notes:
+- links: []
+  text: 'mPDF version 7.1.7 and earlier contains a CWE-502: Deserialization of Untrusted
+    Data vulnerability in getImage() method of Image/ImageProcessor class that can
+    result in Arbitry code execution, file write, etc.. This attack appears to be
+    exploitable via attacker must host crafted image on victim server and trigger
+    generation of pdf file with content <img src="phar://path/to/crafted/image">.
+    This vulnerability appears to have been fixed in 7.1.8.'
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 20ff6399433c18233f31817ba2f35a86dd9d5e22
+    repository: https://github.com/mpdf/mpdf

--- a/statements/CVE-2019-1000021/statement.yaml
+++ b/statements/CVE-2019-1000021/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2019-1000021
+notes:
+- links: []
+  text: slixmpp version before commit 7cd73b594e8122dddf847953fcfc85ab4d316416 contains
+    an incorrect Access Control vulnerability in XEP-0223 plugin (Persistent Storage
+    of Private Data via PubSub) options profile, used for the configuration of default
+    access model that can result in all of the contacts of the victim can see private
+    data having been published to a PEP node. This attack appears to be exploitable
+    if the user of this library publishes any private data on PEP, the node isn't
+    configured to be private. This vulnerability appears to have been fixed in commit
+    7cd73b594e8122dddf847953fcfc85ab4d316416 which is included in slixmpp 1.4.2.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7cd73b594e8122dddf847953fcfc85ab4d316416
+    repository: https://github.com/poezio/slixmpp

--- a/statements/CVE-2019-10131/statement.yaml
+++ b/statements/CVE-2019-10131/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10131
+notes:
+- links: []
+  text: An off-by-one read vulnerability was discovered in ImageMagick before version
+    7.0.7-28 in the formatIPTCfromBuffer function in coders/meta.c. A local attacker
+    may use this flaw to read beyond the end of the buffer or to crash the program.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: cb1214c124e1bd61f7dd551b94a794864861592e
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2019-10157/statement.yaml
+++ b/statements/CVE-2019-10157/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-10157
+notes:
+- links: []
+  text: It was found that Keycloak's Node.js adapter before version 4.8.3 did not
+    properly verify the web token received from the server in its backchannel logout
+    . An attacker with local access could use this to construct a malicious web token
+    setting an NBF parameter that could prevent user access indefinitely.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 55e54b55d05ba636bc125a8f3d39f0052d13f8f6
+    repository: https://github.com/keycloak/keycloak-nodejs-connect

--- a/statements/CVE-2019-1020012/statement.yaml
+++ b/statements/CVE-2019-1020012/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2019-1020012
+notes:
+- links: []
+  text: parse-server before 3.4.1 allows DoS after any POST to a volatile class.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8709daf698ea69b59268cb66f0f7cee75b52daa5
+    repository: https://github.com/parse-community/parse-server

--- a/statements/CVE-2019-10248/statement.yaml
+++ b/statements/CVE-2019-10248/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-10248
+notes:
+- links: []
+  text: Eclipse Vorto versions prior to 0.11 resolved Maven build artifacts for the
+    Xtext project over HTTP instead of HTTPS. Any of these dependent artifacts could
+    have been maliciously compromised by a MITM attack. Hence produced build artifacts
+    of Vorto might be infected.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f15b81fb76b214fe40be164dfb730434ef49ec35
+    repository: https://github.com/eclipse/vorto

--- a/statements/CVE-2019-1052/statement.yaml
+++ b/statements/CVE-2019-1052/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1052
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-0989, CVE-2019-0991,
+    CVE-2019-0992, CVE-2019-0993, CVE-2019-1002, CVE-2019-1003, CVE-2019-1024, CVE-2019-1051.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 66ab97c09c49c631234c0ec202b0822d0c2833cc
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-1062/statement.yaml
+++ b/statements/CVE-2019-1062/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1062
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1092, CVE-2019-1103,
+    CVE-2019-1106, CVE-2019-1107.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7f0d390ad77d838cbb81d4586c83ec822f384ce8
+    repository: https://github.com/microsoft/ChakraCore

--- a/statements/CVE-2019-10642/statement.yaml
+++ b/statements/CVE-2019-10642/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2019-10642
+notes:
+- links: []
+  text: Contao 4.7 allows CSRF.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ee2c8130c2e68a1d0d2e75bd6b774c4393942b15
+    repository: https://github.com/contao/contao

--- a/statements/CVE-2019-10643/statement.yaml
+++ b/statements/CVE-2019-10643/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2019-10643
+notes:
+- links: []
+  text: Contao 4.7 allows Use of a Key Past its Expiration Date.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 70348cc812b110831ad66a4f9857883f75649b88
+    repository: https://github.com/contao/contao

--- a/statements/CVE-2019-10749/statement.yaml
+++ b/statements/CVE-2019-10749/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-10749
+notes:
+- links: []
+  text: sequelize before version 3.35.1 allows attackers to perform a SQL Injection
+    due to the JSON path keys not being properly sanitized in the Postgres dialect.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ee4017379db0059566ecb5424274ad4e2d66bc68
+    repository: https://github.com/sequelize/sequelize

--- a/statements/CVE-2019-10752/statement.yaml
+++ b/statements/CVE-2019-10752/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10752
+notes:
+- links: []
+  text: Sequelize, all versions prior to version 4.44.3 and 5.15.1, is vulnerable
+    to SQL Injection due to sequelize.json() helper function not escaping values properly
+    when formatting sub paths for JSON queries for MySQL, MariaDB and SQLite.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9bd0bc111b6f502223edf7e902680f7cc2ed541e
+    repository: https://github.com/sequelize/sequelize

--- a/statements/CVE-2019-10762/statement.yaml
+++ b/statements/CVE-2019-10762/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-10762
+notes:
+- links: []
+  text: columnQuote in medoo before 1.7.5 allows remote attackers to perform a SQL
+    Injection due to improper escaping.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 659864b393961bf224bba1efc03b7dcbed7de533
+    repository: https://github.com/catfan/Medoo

--- a/statements/CVE-2019-10767/statement.yaml
+++ b/statements/CVE-2019-10767/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-10767
+notes:
+- links: []
+  text: An attacker can include file contents from outside the `/adapter/xxx/` directory,
+    where `xxx` is the name of an existent adapter like "admin". It is exploited using
+    the administrative web panel with a request for an adapter file. **Note:** The
+    attacker has to be logged in if the authentication is enabled (by default isn't
+    enabled).
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f6e292c6750a491a5000d0f851b2fede4f9e2fda
+    repository: https://github.com/ioBroker/ioBroker.js-controller

--- a/statements/CVE-2019-10776/statement.yaml
+++ b/statements/CVE-2019-10776/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10776
+notes:
+- links: []
+  text: In "index.js" file line 240, the run command executes the git command with
+    a user controlled variable called remoteUrl. This affects git-diff-apply all versions
+    prior to 0.22.2.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 106d61d3ae723b4257c2a13e67b95eb40a27e0b5
+    repository: https://github.com/kellyselden/git-diff-apply

--- a/statements/CVE-2019-10781/statement.yaml
+++ b/statements/CVE-2019-10781/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-10781
+notes:
+- links: []
+  text: In schema-inspector before 1.6.9, a maliciously crafted JavaScript object
+    can bypass the `sanitize()` and the `validate()` function used within schema-inspector.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 345a7b2eed11bb6128421150d65f4f83fdbb737d
+    repository: https://github.com/schema-inspector/schema-inspector

--- a/statements/CVE-2019-10787/statement.yaml
+++ b/statements/CVE-2019-10787/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10787
+notes:
+- links: []
+  text: im-resize through 2.3.2 allows remote attackers to execute arbitrary commands
+    via the "exec" argument. The cmd argument used within index.js, can be controlled
+    by user without any sanitization.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: de624dacf6a50e39fe3472af1414d44937ce1f03
+    repository: https://github.com/Turistforeningen/node-im-resize

--- a/statements/CVE-2019-10792/statement.yaml
+++ b/statements/CVE-2019-10792/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10792
+notes:
+- links: []
+  text: bodymen before 1.1.1 is vulnerable to Prototype Pollution. The handler function
+    could be tricked into adding or modifying properties of Object.prototype using
+    a __proto__ payload.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 5d52e8cf360410ee697afd90937e6042c3a8653b
+    repository: https://github.com/diegohaz/bodymen

--- a/statements/CVE-2019-10793/statement.yaml
+++ b/statements/CVE-2019-10793/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10793
+notes:
+- links: []
+  text: dot-object before 2.1.3 is vulnerable to Prototype Pollution. The set function
+    could be tricked into adding or modifying properties of Object.prototype using
+    a __proto__ payload.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f76cff5fe6d01d30ce110d8f454db2e5bd28a7de
+    repository: https://github.com/rhalff/dot-object

--- a/statements/CVE-2019-10795/statement.yaml
+++ b/statements/CVE-2019-10795/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10795
+notes:
+- links: []
+  text: undefsafe before 2.0.3 is vulnerable to Prototype Pollution. The 'a' function
+    could be tricked into adding or modifying properties of Object.prototype using
+    a __proto__ payload.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f272681b3a50e2c4cbb6a8533795e1453382c822
+    repository: https://github.com/remy/undefsafe

--- a/statements/CVE-2019-10799/statement.yaml
+++ b/statements/CVE-2019-10799/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-10799
+notes:
+- links: []
+  text: compile-sass prior to 1.0.5 allows execution of arbritary commands. The function
+    "setupCleanupOnExit(cssPath)" within "dist/index.js" is executed as part of the
+    "rm" command without any sanitization.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d9ada7797ff93875b6466dea7a78768e90a0f8d2
+    repository: https://github.com/eiskalteschatten/compile-sass

--- a/statements/CVE-2019-10867/statement.yaml
+++ b/statements/CVE-2019-10867/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-10867
+notes:
+- links: []
+  text: An issue was discovered in Pimcore before 5.7.1. An attacker with classes
+    permission can send a POST request to /admin/class/bulk-commit, which will make
+    it possible to exploit the unserialize function when passing untrusted values
+    in the data parameter to bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 38a29e2f4f5f060a73974626952501cee05fda73
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-1092/statement.yaml
+++ b/statements/CVE-2019-1092/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1092
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1062, CVE-2019-1103,
+    CVE-2019-1106, CVE-2019-1107.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d4e767fb946128c135d77edda7a794561e1c1f06
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-1103/statement.yaml
+++ b/statements/CVE-2019-1103/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1103
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1062, CVE-2019-1092,
+    CVE-2019-1106, CVE-2019-1107.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: efab3101028045cbfa0cc21bd852f75bcc037dba
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-1106/statement.yaml
+++ b/statements/CVE-2019-1106/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1106
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1062, CVE-2019-1092,
+    CVE-2019-1103, CVE-2019-1107.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 362e96537af207be3ecf7fa32f338229ee1dcc46
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-1107/statement.yaml
+++ b/statements/CVE-2019-1107/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1107
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1062, CVE-2019-1092,
+    CVE-2019-1103, CVE-2019-1106.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 214dec9461f9acb9a4b9004368d2a81e0c125652
+    repository: https://github.com/chakra-core/ChakraCore

--- a/statements/CVE-2019-11358/statement.yaml
+++ b/statements/CVE-2019-11358/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-11358
+notes:
+- links: []
+  text: jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products,
+    mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution.
+    If an unsanitized source object contained an enumerable __proto__ property, it
+    could extend the native Object.prototype.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 753d591aea698e57d6db58c9f722cd0808619b1b
+    repository: https://github.com/jquery/jquery

--- a/statements/CVE-2019-1139/statement.yaml
+++ b/statements/CVE-2019-1139/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1139
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1131, CVE-2019-1140,
+    CVE-2019-1141, CVE-2019-1195, CVE-2019-1196, CVE-2019-1197.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ae8a8d9644e677a9878e5dd7824d4b876454e799
+    repository: https://github.com/microsoft/ChakraCore

--- a/statements/CVE-2019-11512/statement.yaml
+++ b/statements/CVE-2019-11512/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2019-11512
+notes:
+- links: []
+  text: Contao 4.x allows SQL Injection. Fixed in Contao 4.4.39 and Contao 4.7.5.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 87d92f823b08b91a0aeb522284537c8afcdb8aba
+    repository: https://github.com/contao/contao

--- a/statements/CVE-2019-11514/statement.yaml
+++ b/statements/CVE-2019-11514/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-11514
+notes:
+- links: []
+  text: User/Command/ConfirmEmailHandler.php in Flarum before 0.1.0-beta.8 mishandles
+    invalidation of user email tokens.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 66607a56749339d50620b049701ad4d6a4dafbd7
+    repository: https://github.com/flarum/core

--- a/statements/CVE-2019-11768/statement.yaml
+++ b/statements/CVE-2019-11768/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-11768
+notes:
+- links: []
+  text: An issue was discovered in phpMyAdmin before 4.9.0.1. A vulnerability was
+    reported where a specially crafted database name can be used to trigger an SQL
+    injection attack through the designer feature.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c1ecafc38319e8f768c9259d4d580e42acd5ee86
+    repository: https://github.com/phpmyadmin/phpmyadmin

--- a/statements/CVE-2019-1195/statement.yaml
+++ b/statements/CVE-2019-1195/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1195
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1131, CVE-2019-1139,
+    CVE-2019-1140, CVE-2019-1141, CVE-2019-1196, CVE-2019-1197.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c70af488e435ebd552f3da0547dee39dc8437a64
+    repository: https://github.com/microsoft/ChakraCore

--- a/statements/CVE-2019-1196/statement.yaml
+++ b/statements/CVE-2019-1196/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1196
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1131, CVE-2019-1139,
+    CVE-2019-1140, CVE-2019-1141, CVE-2019-1195, CVE-2019-1197.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: dce7443ae45f82eceec3284974610e1a1bbe6792
+    repository: https://github.com/microsoft/ChakraCore

--- a/statements/CVE-2019-1197/statement.yaml
+++ b/statements/CVE-2019-1197/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-1197
+notes:
+- links: []
+  text: A remote code execution vulnerability exists in the way that the Chakra scripting
+    engine handles objects in memory in Microsoft Edge, aka 'Chakra Scripting Engine
+    Memory Corruption Vulnerability'. This CVE ID is unique from CVE-2019-1131, CVE-2019-1139,
+    CVE-2019-1140, CVE-2019-1141, CVE-2019-1195, CVE-2019-1196.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bf52b6cfa96d6395046d0aaf87396cd7ca13f6cb
+    repository: https://github.com/microsoft/ChakraCore

--- a/statements/CVE-2019-12277/statement.yaml
+++ b/statements/CVE-2019-12277/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-12277
+notes:
+- links: []
+  text: Blogifier 2.3 before 2019-05-11 does not properly restrict APIs, as demonstrated
+    by missing checks for .. in a pathname.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3e2ae11f6be8aab82128f223c2916fab5a408be5
+    repository: https://github.com/blogifierdotnet/Blogifier

--- a/statements/CVE-2019-12616/statement.yaml
+++ b/statements/CVE-2019-12616/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-12616
+notes:
+- links: []
+  text: An issue was discovered in phpMyAdmin before 4.9.0. A vulnerability was found
+    that allows an attacker to trigger a CSRF attack against a phpMyAdmin user. The
+    attacker can trick the user, for instance through a broken <img> tag pointing
+    at the victim's phpMyAdmin database, and the attacker can potentially deliver
+    a payload (such as a specific INSERT or DELETE statement) to the victim.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 015c404038c44279d95b6430ee5a0dddc97691ec
+    repository: https://github.com/phpmyadmin/phpmyadmin

--- a/statements/CVE-2019-13127/statement.yaml
+++ b/statements/CVE-2019-13127/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-13127
+notes:
+- links: []
+  text: An issue was discovered in mxGraph through 4.0.0, related to the "draw.io
+    Diagrams" plugin before 8.3.14 for Confluence and other products. Improper input
+    validation/sanitization of a color field leads to XSS. This is associated with
+    javascript/examples/grapheditor/www/js/Dialogs.js.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 76e8e2809b622659a9c5ffdc4f19922b7a68cfa3
+    repository: https://github.com/jgraph/mxgraph

--- a/statements/CVE-2019-13173/statement.yaml
+++ b/statements/CVE-2019-13173/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-13173
+notes:
+- links: []
+  text: fstream before 1.0.12 is vulnerable to Arbitrary File Overwrite. Extracting
+    tarballs containing a hardlink to a file that already exists in the system, and
+    a file that matches the hardlink, will overwrite the system's file with the contents
+    of the extracted file. The fstream.DirWriter() function is vulnerable.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6a77d2fa6e1462693cf8e46f930da96ec1b0bb22
+    repository: https://github.com/npm/fstream

--- a/statements/CVE-2019-13295/statement.yaml
+++ b/statements/CVE-2019-13295/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-13295
+notes:
+- links: []
+  text: ImageMagick 7.0.8-50 Q16 has a heap-based buffer over-read at MagickCore/threshold.c
+    in AdaptiveThresholdImage because a width of zero is mishandled.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: a7759f410b773a1dd57b0e1fb28112e1cd8b97bc
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2019-14668/statement.yaml
+++ b/statements/CVE-2019-14668/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-14668
+notes:
+- links: []
+  text: Firefly III 4.7.17.3 is vulnerable to stored XSS due to the lack of filtration
+    of user-supplied data in the transaction description field. The JavaScript code
+    is executed during deletion of a transaction link.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3ad4e04e2ae50e60564b60b68dfac083e5684882
+    repository: https://github.com/firefly-iii/firefly-iii

--- a/statements/CVE-2019-14669/statement.yaml
+++ b/statements/CVE-2019-14669/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-14669
+notes:
+- links: []
+  text: Firefly III 4.7.17.3 is vulnerable to stored XSS due to the lack of filtration
+    of user-supplied data in the asset account name. The JavaScript code is executed
+    during a visit to the audit account statistics page.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 2ddf48f15cbdbb475221c299872420f625c3bc3f
+    repository: https://github.com/firefly-iii/firefly-iii

--- a/statements/CVE-2019-14671/statement.yaml
+++ b/statements/CVE-2019-14671/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-14671
+notes:
+- links: []
+  text: Firefly III 4.7.17.3 is vulnerable to local file enumeration. An attacker
+    can enumerate local files due to the lack of protocol scheme sanitization, such
+    as for file:/// URLs. This is related to fints_url to import/job/configuration,
+    and import/create/fints.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e80d616ef4397e6e764f6b7b7a5b30121244933c
+    repository: https://github.com/firefly-iii/firefly-iii

--- a/statements/CVE-2019-14672/statement.yaml
+++ b/statements/CVE-2019-14672/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-14672
+notes:
+- links: []
+  text: Firefly III 4.7.17.5 is vulnerable to stored XSS due to the lack of filtration
+    of user-supplied data in the liability name field. The JavaScript code is executed
+    upon an error condition during a visit to the account show page.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8717f469b10e9f7e1547c6f70f7d24e1359d28d4
+    repository: https://github.com/firefly-iii/firefly-iii

--- a/statements/CVE-2019-14806/statement.yaml
+++ b/statements/CVE-2019-14806/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-14806
+notes:
+- links: []
+  text: Pallets Werkzeug before 0.15.3, when used with Docker, has insufficient debugger
+    PIN randomness because Docker containers share the same machine id.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 00bc43b1672e662e5e3b8cecd79e67fc968fa246
+    repository: https://github.com/pallets/werkzeug

--- a/statements/CVE-2019-14837/statement.yaml
+++ b/statements/CVE-2019-14837/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-14837
+notes:
+- links: []
+  text: A flaw was found in keycloack before version 8.0.0. The owner of 'placeholder.org'
+    domain can setup mail server on this domain and knowing only name of a client
+    can reset password and then log in. For example, for client name 'test' the email
+    address will be 'service-account-test@placeholder.org'.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9a7c1a91a59ab85e7f8889a505be04a71580777f
+    repository: https://github.com/keycloak/keycloak

--- a/statements/CVE-2019-14862/statement.yaml
+++ b/statements/CVE-2019-14862/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-14862
+notes:
+- links: []
+  text: There is a vulnerability in knockout before version 3.5.0-beta, where after
+    escaping the context of the web application, the web application delivers data
+    to its users along with other trusted dynamic content, without validating it.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 7e280b2b8a04cc19176b5171263a5c68bda98efb
+    repository: https://github.com/knockout/knockout

--- a/statements/CVE-2019-14980/statement.yaml
+++ b/statements/CVE-2019-14980/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-14980
+notes:
+- links: []
+  text: In ImageMagick 7.x before 7.0.8-42 and 6.x before 6.9.10-42, there is a use
+    after free vulnerability in the UnmapBlob function that allows an attacker to
+    cause a denial of service by sending a crafted file.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c5d012a46ae22be9444326aa37969a3f75daa3ba
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2019-15658/statement.yaml
+++ b/statements/CVE-2019-15658/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-15658
+notes:
+- links: []
+  text: connect-pg-simple before 6.0.1 allows SQL injection if tableName or schemaName
+    is untrusted data.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: df61c9507f804ba72803e4f567c3cbcfa0a9d7e1
+    repository: https://github.com/voxpelli/node-connect-pg-simple

--- a/statements/CVE-2019-16317/statement.yaml
+++ b/statements/CVE-2019-16317/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-16317
+notes:
+- links: []
+  text: In Pimcore before 5.7.1, an attacker with limited privileges can trigger execution
+    of a .phar file via a phar:// URL in a filename parameter, because PHAR uploads
+    are not blocked and are reachable within the phar://../../../../../../../../var/www/html/web/var/assets/
+    directory, a different vulnerability than CVE-2019-10867 and CVE-2019-16318.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6ee5d8536d0802e377594cbe39083e822710aab9
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-16318/statement.yaml
+++ b/statements/CVE-2019-16318/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-16318
+notes:
+- links: []
+  text: In Pimcore before 5.7.1, an attacker with limited privileges can bypass file-extension
+    restrictions via a 256-character filename, as demonstrated by the failure of automatic
+    renaming of .php to .php.txt for long filenames, a different vulnerability than
+    CVE-2019-10867 and CVE-2019-16317.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 732f1647cc6e0a29b5b1f5d904b4d726b5e9455f
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-16676/statement.yaml
+++ b/statements/CVE-2019-16676/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-16676
+notes:
+- links: []
+  text: Plataformatec Simple Form has Incorrect Access Control in file_method? in
+    lib/simple_form/form_builder.rb, because a user-supplied string is invoked as
+    a method call.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 8c91bd76a5052ddf3e3ab9fd8333f9aa7b2e2dd6
+    repository: https://github.com/heartcombo/simple_form

--- a/statements/CVE-2019-16761/statement.yaml
+++ b/statements/CVE-2019-16761/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-16761
+notes:
+- links: []
+  text: A specially crafted Bitcoin script can cause a discrepancy between the specified
+    SLP consensus rules and the validation result of the slp-validate@1.0.0 npm package.
+    An attacker could create a specially crafted Bitcoin script in order to cause
+    a hard-fork from the SLP consensus. All versions >1.0.0 have been patched.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 50ad96c2798dad6b9f9a13333dd05232defe5730
+    repository: https://github.com/simpleledger/slp-validate.js

--- a/statements/CVE-2019-16762/statement.yaml
+++ b/statements/CVE-2019-16762/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-16762
+notes:
+- links: []
+  text: A specially crafted Bitcoin script can cause a discrepancy between the specified
+    SLP consensus rules and the validation result of the slpjs npm package. An attacker
+    could create a specially crafted Bitcoin script in order to cause a hard-fork
+    from the SLP consensus. Affected users can upgrade to any version >= 0.21.4.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ac8809b42e47790a6f0205991b36f2699ed10c84
+    repository: https://github.com/simpleledger/slpjs

--- a/statements/CVE-2019-16763/statement.yaml
+++ b/statements/CVE-2019-16763/statement.yaml
@@ -1,0 +1,18 @@
+vulnerability_id: CVE-2019-16763
+notes:
+- links: []
+  text: In Pannellum from 2.5.0 through 2.5.4 URLs were not sanitized for data URIs
+    (or vbscript:), allowing for potential XSS attacks. Such an attack would require
+    a user to click on a hot spot to execute and would require an attacker-provided
+    configuration. The most plausible potential attack would be if pannellum.htm was
+    hosted on a domain that shared cookies with the targeted site's user authentication;
+    an &lt;iframe&gt; could then be embedded on the attacker's site using pannellum.htm
+    from the targeted site, which would allow the attacker to potentially access information
+    from the targeted site as the authenticated user (or worse if the targeted site
+    did not have adequate CSRF protections) if the user clicked on a hot spot in the
+    attacker's embedded panorama viewer. This was patched in version 2.5.5.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: cc2f3d99953de59db908e0c6efd1c2c17f7c6914
+    repository: https://github.com/mpetroff/pannellum

--- a/statements/CVE-2019-16769/statement.yaml
+++ b/statements/CVE-2019-16769/statement.yaml
@@ -1,0 +1,15 @@
+vulnerability_id: CVE-2019-16769
+notes:
+- links: []
+  text: The serialize-javascript npm package before version 2.1.1 is vulnerable to
+    Cross-site Scripting (XSS). It does not properly mitigate against unsafe characters
+    in serialized regular expressions. This vulnerability is not affected on Node.js
+    environment since Node.js's implementation of RegExp.prototype.toString() backslash-escapes
+    all forward slashes in regular expressions. If serialized data of regular expression
+    objects are used in an environment other than Node.js, it is affected by this
+    vulnerability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 16a68ab53d9626fc7c942b48a1163108fcd184c8
+    repository: https://github.com/yahoo/serialize-javascript

--- a/statements/CVE-2019-16778/statement.yaml
+++ b/statements/CVE-2019-16778/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-16778
+notes:
+- links: []
+  text: In TensorFlow before 1.15, a heap buffer overflow in UnsortedSegmentSum can
+    be produced when the Index template argument is int32. In this case data_size
+    and num_segments fields are truncated from int64 to int32 and can produce negative
+    numbers, resulting in accessing out of bounds heap memory. This is unlikely to
+    be exploitable and was detected and fixed internally in TensorFlow 1.15 and 2.0.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: db4f9717c41bccc3ce10099ab61996b246099892
+    repository: https://github.com/tensorflow/tensorflow

--- a/statements/CVE-2019-16779/statement.yaml
+++ b/statements/CVE-2019-16779/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2019-16779
+notes:
+- links: []
+  text: In RubyGem excon before 0.71.0, there was a race condition around persistent
+    connections, where a connection which is interrupted (such as by a timeout) would
+    leave data on the socket. Subsequent requests would then read this data, returning
+    content from the previous response. The race condition window appears to be short,
+    and it would be difficult to purposefully exploit this.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ccb57d7a422f020dc74f1de4e8fb505ab46d8a29
+    repository: https://github.com/excon/excon

--- a/statements/CVE-2019-17496/statement.yaml
+++ b/statements/CVE-2019-17496/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-17496
+notes:
+- links: []
+  text: Craft CMS before 3.3.8 has stored XSS via a name field. This field is mishandled
+    during site deletion.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0ee66d29281af2b6c4f866e1437842c61983a672
+    repository: https://github.com/craftcms/cms

--- a/statements/CVE-2019-17541/statement.yaml
+++ b/statements/CVE-2019-17541/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-17541
+notes:
+- links: []
+  text: ImageMagick before 7.0.8-55 has a use-after-free in DestroyStringInfo in MagickCore/string.c
+    because the error manager is mishandled in coders/jpeg.c.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 39f226a9c137f547e12afde972eeba7551124493
+    repository: https://github.com/ImageMagick/ImageMagick

--- a/statements/CVE-2019-17592/statement.yaml
+++ b/statements/CVE-2019-17592/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-17592
+notes:
+- links: []
+  text: The csv-parse module before 4.4.6 for Node.js is vulnerable to Regular Expression
+    Denial of Service. The __isInt() function contains a malformed regular expression
+    that processes large crafted input very slowly. This is triggered when using the
+    cast option.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: b9d35940c6815cdf1dfd6b21857a1f6d0fd51e4a
+    repository: https://github.com/adaltas/node-csv-parse

--- a/statements/CVE-2019-18622/statement.yaml
+++ b/statements/CVE-2019-18622/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-18622
+notes:
+- links: []
+  text: An issue was discovered in phpMyAdmin before 4.9.2. A crafted database/table
+    name can be used to trigger a SQL injection attack through the designer feature.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ff541af95d7155d8dd326f331b5e248fea8e7111
+    repository: https://github.com/phpmyadmin/phpmyadmin

--- a/statements/CVE-2019-18656/statement.yaml
+++ b/statements/CVE-2019-18656/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-18656
+notes:
+- links: []
+  text: Pimcore 6.2.3 has XSS in the translations grid because bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
+    mishandles certain HTML elements.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: ca036e9f86bb5cdb3dac0930ec131e5f35e26c5f
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-18857/statement.yaml
+++ b/statements/CVE-2019-18857/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-18857
+notes:
+- links: []
+  text: darylldoyle svg-sanitizer before 0.12.0 mishandles script and data values
+    in attributes, as demonstrated by unexpected whitespace such as in the javascript&#9;:alert
+    substring.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 51ca4b713f3706d6b27769c6296bbc0c28a5bbd0
+    repository: https://github.com/darylldoyle/svg-sanitizer

--- a/statements/CVE-2019-18981/statement.yaml
+++ b/statements/CVE-2019-18981/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-18981
+notes:
+- links: []
+  text: Pimcore before 6.2.2 lacks an Access Denied outcome for a certain scenario
+    of an incorrect recipient ID of a notification.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0a5d80b2593b2ebe35d19756b730ba33aa049106
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-18982/statement.yaml
+++ b/statements/CVE-2019-18982/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-18982
+notes:
+- links: []
+  text: bundles/AdminBundle/Controller/Admin/EmailController.php in Pimcore before
+    6.3.0 allows script execution in the Email Log preview window because of the lack
+    of a Content-Security-Policy header.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e0b48faf7d29ce43a98825a0b230e88350ebcf78
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-18985/statement.yaml
+++ b/statements/CVE-2019-18985/statement.yaml
@@ -1,0 +1,9 @@
+vulnerability_id: CVE-2019-18985
+notes:
+- links: []
+  text: Pimcore before 6.2.2 lacks brute force protection for the 2FA token.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 9f2d075243a8392c114d9a8028858b9faf041e2d
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-18986/statement.yaml
+++ b/statements/CVE-2019-18986/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-18986
+notes:
+- links: []
+  text: Pimcore before 6.2.2 allow attackers to brute-force (guess) valid usernames
+    by using the 'forgot password' functionality as it returns distinct messages for
+    invalid password and non-existing users.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4a7bba5c3f818852cbbd29fa124f7fb09a207185
+    repository: https://github.com/pimcore/pimcore

--- a/statements/CVE-2019-19576/statement.yaml
+++ b/statements/CVE-2019-19576/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-19576
+notes:
+- links: []
+  text: class.upload.php in verot.net class.upload before 1.0.3 and 2.x before 2.0.4,
+    as used in the K2 extension for Joomla! and other products, omits .phar from the
+    set of dangerous file extensions.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: d1344706c4b74c2ae7659b286b5a066117155124
+    repository: https://github.com/getk2/k2

--- a/statements/CVE-2019-19703/statement.yaml
+++ b/statements/CVE-2019-19703/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-19703
+notes:
+- links: []
+  text: In Ktor through 1.2.6, the client resends data from the HTTP Authorization
+    header to a redirect location.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0c108156f45423d09014b47be810188629cb878f
+    repository: https://github.com/ktorio/ktor

--- a/statements/CVE-2019-3564/statement.yaml
+++ b/statements/CVE-2019-3564/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-3564
+notes:
+- links: []
+  text: Go Facebook Thrift servers would not error upon receiving messages with containers
+    of fields of unknown type. As a result, malicious clients could send short messages
+    which would take a long time for the server to parse, potentially leading to denial
+    of service. This issue affects Facebook Thrift prior to v2019.03.04.00.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c461c1bd1a3e130b181aa9c854da3030cd4b5156
+    repository: https://github.com/facebook/fbthrift

--- a/statements/CVE-2019-5018/statement.yaml
+++ b/statements/CVE-2019-5018/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2019-5018
+notes:
+- links: []
+  text: An exploitable use after free vulnerability exists in the window function
+    functionality of Sqlite3 3.26.0. A specially crafted SQL command can cause a use
+    after free vulnerability, potentially resulting in remote code execution. An attacker
+    can send a malicious SQL command to trigger this vulnerability.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 4ded26a53c4df312e9fd06facbbf70377e969983
+    repository: https://github.com/sqlite/sqlite

--- a/statements/CVE-2019-5413/statement.yaml
+++ b/statements/CVE-2019-5413/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-5413
+notes:
+- links: []
+  text: An attacker can use the format parameter to inject arbitrary commands in the
+    npm package morgan < 1.9.1.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e329663836809de4be557b200a5b983ab8b4e6c2
+    repository: https://github.com/expressjs/morgan

--- a/statements/CVE-2019-5484/statement.yaml
+++ b/statements/CVE-2019-5484/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-5484
+notes:
+- links: []
+  text: Bower before 1.8.8 has a path traversal vulnerability permitting file write
+    in arbitrary locations via install command, which allows attackers to write arbitrary
+    files when a malicious package is extracted.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 45c6bfa86f6e57731b153baca9e0b41a1cc699e3
+    repository: https://github.com/bower/bower

--- a/statements/CVE-2019-6798/statement.yaml
+++ b/statements/CVE-2019-6798/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2019-6798
+notes:
+- links: []
+  text: An issue was discovered in phpMyAdmin before 4.8.5. A vulnerability was reported
+    where a specially crafted username can be used to trigger a SQL injection attack
+    through the designer feature.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 469934cf7d3bd19a839eb78670590f7511399435
+    repository: https://github.com/phpmyadmin/phpmyadmin

--- a/statements/CVE-2019-8457/statement.yaml
+++ b/statements/CVE-2019-8457/statement.yaml
@@ -1,0 +1,10 @@
+vulnerability_id: CVE-2019-8457
+notes:
+- links: []
+  text: SQLite3 from 3.6.0 to and including 3.27.2 is vulnerable to heap out-of-bound
+    read in the rtreenode() function when handling invalid rtree tables.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: e41fd72acc7a06ce5a6a7d28154db1ffe8ba37a8
+    repository: https://github.com/sqlite/sqlite

--- a/statements/CVE-2020-10236/statement.yaml
+++ b/statements/CVE-2020-10236/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2020-10236
+notes:
+- links: []
+  text: An issue was discovered in Froxlor before 0.10.14. It created files with static
+    names in /tmp during installation if the installation directory was not writable.
+    This allowed local attackers to cause DoS or disclose information out of the config
+    files, because of _createUserdataConf in install/lib/class.FroxlorInstall.php.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 6b09720ef8a1cc008751dd0ca0140a0597fedce5
+    repository: https://github.com/Froxlor/Froxlor

--- a/statements/CVE-2020-5219/statement.yaml
+++ b/statements/CVE-2020-5219/statement.yaml
@@ -1,0 +1,14 @@
+vulnerability_id: CVE-2020-5219
+notes:
+- links: []
+  text: Angular Expressions before version 1.0.1 has a remote code execution vulnerability
+    if you call expressions.compile(userControlledInput) where userControlledInput
+    is text that comes from user input. If running angular-expressions in the browser,
+    an attacker could run any browser script when the application code calls expressions.compile(userControlledInput).
+    If running angular-expressions on the server, an attacker could run any Javascript
+    expression, thus gaining Remote Code Execution.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 061addfb9a9e932a970e5fcb913d020038e65667
+    repository: https://github.com/peerigon/angular-expressions

--- a/statements/CVE-2020-5224/statement.yaml
+++ b/statements/CVE-2020-5224/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2020-5224
+notes:
+- links: []
+  text: In Django User Sessions (django-user-sessions) before 1.7.1, the views provided
+    allow users to terminate specific sessions. The session key is used to identify
+    sessions, and thus included in the rendered HTML. In itself this is not a problem.
+    However if the website has an XSS vulnerability, the session key could be extracted
+    by the attacker and a session takeover could happen.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f0c4077e7d1436ba6d721af85cee89222ca5d2d9
+    repository: https://github.com/jazzband/django-user-sessions

--- a/statements/CVE-2020-5232/statement.yaml
+++ b/statements/CVE-2020-5232/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2020-5232
+notes:
+- links: []
+  text: A user who owns an ENS domain can set a trapdoor, allowing them to transfer
+    ownership to another user, and later regain ownership without the new owners consent
+    or awareness. A new ENS deployment is being rolled out that fixes this vulnerability
+    in the ENS registry.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 36e10e71fcddcade88646821e0a57cc6c19e1ecf
+    repository: https://github.com/ensdomains/ens

--- a/statements/CVE-2020-5249/statement.yaml
+++ b/statements/CVE-2020-5249/statement.yaml
@@ -1,0 +1,16 @@
+vulnerability_id: CVE-2020-5249
+notes:
+- links: []
+  text: In Puma (RubyGem) before 4.3.3 and 3.12.4, if an application using Puma allows
+    untrusted input in an early-hints header, an attacker can use a carriage return
+    character to end the header and inject malicious content, such as additional headers
+    or an entirely new response body. This vulnerability is known as HTTP Response
+    Splitting. While not an attack in itself, response splitting is a vector for several
+    other attacks, such as cross-site scripting (XSS). This is related to CVE-2020-5247,
+    which fixed this vulnerability but only for regular responses. This has been fixed
+    in 4.3.3 and 3.12.4.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: c22712fc93284a45a93f9ad7023888f3a65524f3
+    repository: https://github.com/puma/puma

--- a/statements/CVE-2020-6836/statement.yaml
+++ b/statements/CVE-2020-6836/statement.yaml
@@ -1,0 +1,13 @@
+vulnerability_id: CVE-2020-6836
+notes:
+- links: []
+  text: grammar-parser.jison in the hot-formula-parser package before 3.0.1 for Node.js
+    is vulnerable to arbitrary code injection. The package fails to sanitize values
+    passed to the parse function and concatenates them in an eval call. If a value
+    of the formula is taken from user-controlled input, it may allow attackers to
+    run arbitrary commands on the server.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 396b089738d4bf30eb570a4fe6a188affa95cd5e
+    repository: https://github.com/handsontable/formula-parser

--- a/statements/CVE-2020-7597/statement.yaml
+++ b/statements/CVE-2020-7597/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2020-7597
+notes:
+- links: []
+  text: codecov-node npm module before 3.6.5 allows remote attackers to execute arbitrary
+    commands.The value provided as part of the gcov-root argument is executed by the
+    exec function within lib/codecov.js. This vulnerability exists due to an incomplete
+    fix of CVE-2020-7596.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 02cf13d8b93ac547b5b4c2cfe186b7d874fd234f
+    repository: https://github.com/codecov/codecov-node

--- a/statements/CVE-2020-8131/statement.yaml
+++ b/statements/CVE-2020-8131/statement.yaml
@@ -1,0 +1,11 @@
+vulnerability_id: CVE-2020-8131
+notes:
+- links: []
+  text: Arbitrary filesystem write vulnerability in Yarn before 1.22.0 allows attackers
+    to write to any path on the filesystem and potentially lead to arbitrary code
+    execution by forcing the user to install a malicious package.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 0e7133ca28618513503b4e1d9063f1c18ea318e5
+    repository: https://github.com/yarnpkg/yarn

--- a/statements/CVE-2020-9283/statement.yaml
+++ b/statements/CVE-2020-9283/statement.yaml
@@ -1,0 +1,12 @@
+vulnerability_id: CVE-2020-9283
+notes:
+- links: []
+  text: golang.org/x/crypto before v0.0.0-20200220183623-bac4c82f6975 for Go allows
+    a panic during signature verification in the golang.org/x/crypto/ssh package.
+    A client can attack an SSH server that accepts public keys. Also, a server can
+    attack any SSH client.
+fixes:
+- id: DEFAULT_BRANCH
+  commits:
+  - id: bac4c82f69751a6dd76e702d54b3ceb88adab236
+    repository: https://github.com/golang/crypto


### PR DESCRIPTION
# Summary

This dataset contains 307 vulnerability statements found with [Prospector](https://sap.github.io/project-kb/prospector/), an open-source repository mining tool developed by SAP Security Research and the [AssureMOSS consortium](https://assuremoss.eu).
The vulnerabilities covered by this dataset are obtained from the dataset built by [Tracer](https://github.com/patch-tracer/patch-tracer.github.io).

# Data Structure

The dataset is made of a directory containing statements (files in YAML format) obtained through an analysis process. The process used to obtain the statements is described below.

# Analysis Process

## Prospector Execution
The process begins by executing Prospector to automatically identify fix commits for every vulnerability listed in the Tracer dataset, using the vulnerability identifier and the URL of the vulnerable project's GitHub repository as input parameters. The dataset was used for both input parameters. 

## Validation

Our goal is to disclose an additional batch of vulnerability statements from the Tracer dataset and to make them available to the community. To do so, we used Prospector to search for fix commits for the vulnerabilities corresponding to the list of vulnerabilities of the Tracer dataset and we compared the findings of the tool with the commits identified by Tracer. 

Upon completion of Prospector execution, an evaluation was performed examining all results from Prospector's findings, extracting candidate fix commits based on the rules that matched.
The ranking system of Prospector evaluates each candidate fix commit based on predefined rules, assigning a relevance value to each. To ensure the highest level of confidence in identifying the commit as an effective patch, the statements released with this PR only contain fix commits that matched at least one high-relevance rule.

After having extracted all high-confidence commits from Prospector's findings and grouped them for each vulnerability, we compared the results with the Tracer dataset. We decided to release as valid statements those in which Prospector results matched exactly the fix commit that appeared in the Tracer Dataset. For now, any vulnerabilities in the dataset that have multiple fix commits were excluded

# See also

- https://zenodo.org/record/8173991 

# How to cite this dataset

> A. Sabetta, S. E. Ponta, M. Greco, T. Sacchetti, M. Bezzi, "AssureMOSS Vulnerability Statements (Tracer)", 10.5281/zenodo.8173991, 2023 