### PR TITLE
Implements Rule Phases

### DIFF
--- a/prospector/cli/main.py
+++ b/prospector/cli/main.py
@@ -68,7 +68,7 @@ def main(argv):  # noqa: C901
                 )
                 return
 
-            # Create the LLMService singleton for later use
+            # Create the LLMService Singleton for later use
             try:
                 LLMService(config.llm_service)
             except Exception as e:
@@ -104,6 +104,7 @@ def main(argv):  # noqa: C901
         limit_candidates=config.max_candidates,
         # ignore_adv_refs=config.ignore_refs,
         use_llm_repository_url=config.llm_service.use_llm_repository_url,
+        enabled_rules=config.enabled_rules,
     )
 
     if config.preprocess_only:

--- a/prospector/config-sample.yaml
+++ b/prospector/config-sample.yaml
@@ -36,6 +36,27 @@ redis_url: redis://redis:6379/0
 
 #   use_llm_repository_url: False # whether to use LLM's to obtain the repository URL
 
+enabled_rules:
+  # Phase 1 Rules
+  - VULN_ID_IN_MESSAGE
+  - XREF_BUG
+  - XREF_GH
+  - COMMIT_IN_REFERENCE
+  - VULN_ID_IN_LINKED_ISSUE
+  - CHANGES_RELEVANT_FILES
+  - CHANGES_RELEVANT_CODE
+  - RELEVANT_WORDS_IN_MESSAGE
+  - ADV_KEYWORDS_IN_FILES
+  - ADV_KEYWORDS_IN_MSG
+  - SEC_KEYWORDS_IN_MESSAGE
+  - SEC_KEYWORDS_IN_LINKED_GH
+  - SEC_KEYWORDS_IN_LINKED_BUG
+  - GITHUB_ISSUE_IN_MESSAGE
+  - BUG_IN_MESSAGE
+  - COMMIT_HAS_TWINS
+  # Phase 2 Rules (llm_service required!):
+  # - COMMIT_IS_SECURITY_RELEVANT
+
 # Report file format: "html", "json", "console" or "all"
 # and the file name
 report:

--- a/prospector/datamodel/commit.py
+++ b/prospector/datamodel/commit.py
@@ -52,6 +52,7 @@ class Commit(BaseModel):
         return self.relevance == other.relevance
 
     def add_match(self, rule: Dict[str, Any]):
+        """Adds a rule to the commit's matched rules. Makes sure that the rule is added in order of relevance."""
         for i, r in enumerate(self.matched_rules):
             if rule["relevance"] == r["relevance"]:
                 self.matched_rules.insert(i, rule)

--- a/prospector/llm/models/gemini.py
+++ b/prospector/llm/models/gemini.py
@@ -60,6 +60,7 @@ class Gemini(LLM):
 
         try:
             response = requests.post(endpoint, headers=headers, json=data)
+            response.raise_for_status()
             return self.parse(response.json())
         except requests.exceptions.HTTPError as http_error:
             logger.error(

--- a/prospector/llm/models/mistral.py
+++ b/prospector/llm/models/mistral.py
@@ -41,6 +41,7 @@ class Mistral(LLM):
 
         try:
             response = requests.post(endpoint, headers=headers, json=data)
+            response.raise_for_status()
             return self.parse(response.json())
         except requests.exceptions.HTTPError as http_error:
             logger.error(

--- a/prospector/llm/models/openai.py
+++ b/prospector/llm/models/openai.py
@@ -44,6 +44,7 @@ class OpenAI(LLM):
 
         try:
             response = requests.post(endpoint, headers=headers, json=data)
+            response.raise_for_status()
             return self.parse(response.json())
         except requests.exceptions.HTTPError as http_error:
             logger.error(

--- a/prospector/requirements.in
+++ b/prospector/requirements.in
@@ -3,6 +3,7 @@ beautifulsoup4
 colorama
 datasketch
 fastapi
+google-cloud-aiplatform==1.49.0
 Jinja2
 langchain
 langchain_openai

--- a/prospector/requirements.txt
+++ b/prospector/requirements.txt
@@ -39,7 +39,7 @@ frozenlist==1.4.1
 fsspec==2024.6.0
 google-api-core==2.19.0
 google-auth==2.29.0
-google-cloud-aiplatform==1.53.0
+google-cloud-aiplatform==1.49.0
 google-cloud-bigquery==3.24.0
 google-cloud-core==2.4.1
 google-cloud-resource-manager==1.12.3

--- a/prospector/rules/rules.py
+++ b/prospector/rules/rules.py
@@ -2,23 +2,31 @@ import re
 from abc import abstractmethod
 from typing import List, Tuple
 
+import requests
+
 from datamodel.advisory import AdvisoryRecord
-from datamodel.commit import Commit
-from datamodel.nlp import clean_string, find_similar_words
+from datamodel.commit import Commit, apply_ranking
+from llm.llm_service import LLMService
 from rules.helpers import extract_security_keywords
 from stats.execution import Counter, execution_statistics
 from util.lsh import build_lsh_index, decode_minhash
+
+NUM_COMMITS_PHASE_2 = (
+    10  # Determines how many candidates the second rule phase is applied to
+)
+
 
 rule_statistics = execution_statistics.sub_collection("rules")
 
 
 class Rule:
     lsh_index = None
+    llm_service: LLMService = None
 
     def __init__(self, id: str, relevance: int):
         self.id = id
-        self.message = ""
         self.relevance = relevance
+        self.message = ""
 
     @abstractmethod
     def apply(self, candidate: Commit, advisory_record: AdvisoryRecord) -> bool:
@@ -37,54 +45,50 @@ class Rule:
     def get_rule_as_tuple(self) -> Tuple[str, str, int]:
         return (self.id, self.message, self.relevance)
 
+    def get_id(self):
+        return self.id
+
 
 def apply_rules(
     candidates: List[Commit],
     advisory_record: AdvisoryRecord,
-    rules=["ALL"],
+    enabled_rules: List[str] = [],
 ) -> List[Commit]:
-    enabled_rules = get_enabled_rules(rules)
+    """Applies the selected set of rules and returns the ranked list of commits."""
 
-    rule_statistics.collect("active", len(enabled_rules), unit="rules")
+    phase_1_rules = [rule for rule in RULES_PHASE_1 if rule.get_id() in enabled_rules]
+    phase_2_rules = [rule for rule in RULES_PHASE_2 if rule.get_id() in enabled_rules]
+
+    if phase_2_rules:
+        Rule.llm_service = LLMService()
+
+    rule_statistics.collect(
+        "active", len(phase_1_rules) + len(phase_2_rules), unit="rules"
+    )
 
     Rule.lsh_index = build_lsh_index()
-
     for candidate in candidates:
         Rule.lsh_index.insert(candidate.commit_id, decode_minhash(candidate.minhash))
 
     with Counter(rule_statistics) as counter:
         counter.initialize("matches", unit="matches")
         for candidate in candidates:
-            for rule in enabled_rules:
+            for rule in phase_1_rules:
                 if rule.apply(candidate, advisory_record):
                     counter.increment("matches")
                     candidate.add_match(rule.as_dict())
             candidate.compute_relevance()
 
-    # for candidate in candidates:
-    #     if candidate.has_twin():
-    #         for twin in candidate.twins:
-    #             for other_candidate in candidates:
-    #                 if (
-    #                     other_candidate.commit_id == twin[1]
-    #                     and other_candidate.relevance > candidate.relevance
-    #                 ):
-    #                     candidate.relevance = other_candidate.relevance
-    #                     # Add a reason on why we are doing this.
+        candidates = apply_ranking(candidates)
 
-    return candidates
+        for candidate in candidates[:NUM_COMMITS_PHASE_2]:
+            for rule in phase_2_rules:
+                if rule.apply(candidate):
+                    counter.increment("matches")
+                    candidate.add_match(rule.as_dict())
+            candidate.compute_relevance()
 
-
-def get_enabled_rules(rules: List[str]) -> List[Rule]:
-    if "ALL" in rules:
-        return RULES
-
-    enabled_rules = []
-    for r in RULES:
-        if r.id in rules:
-            enabled_rules.append(r)
-
-    return enabled_rules
+    return apply_ranking(candidates)
 
 
 # TODO: This could include issues, PRs, etc.
@@ -409,7 +413,7 @@ class RelevantWordsInMessage(Rule):
         return False
 
 
-RULES: List[Rule] = [
+RULES_PHASE_1: List[Rule] = [
     VulnIdInMessage("VULN_ID_IN_MESSAGE", 64),
     # CommitMentionedInAdv("COMMIT_IN_ADVISORY", 64),
     CrossReferencedBug("XREF_BUG", 32),
@@ -429,23 +433,4 @@ RULES: List[Rule] = [
     CommitHasTwins("COMMIT_HAS_TWINS", 2),
 ]
 
-rules_list = [
-    "COMMIT_IN_REFERENCE",
-    "VULN_ID_IN_MESSAGE",
-    "VULN_ID_IN_LINKED_ISSUE",
-    "XREF_BUG",
-    "XREF_GH",
-    "CHANGES_RELEVANT_FILES",
-    "CHANGES_RELEVANT_CODE",
-    "RELEVANT_WORDS_IN_MESSAGE",
-    "ADV_KEYWORDS_IN_FILES",
-    "ADV_KEYWORDS_IN_MSG",
-    "SEC_KEYWORDS_IN_MESSAGE",
-    "SEC_KEYWORDS_IN_LINKED_GH",
-    "SEC_KEYWORDS_IN_LINKED_BUG",
-    "GITHUB_ISSUE_IN_MESSAGE",
-    "BUG_IN_MESSAGE",
-    "COMMIT_HAS_TWINS",
-]
-
-# print(" & ".join([f"\\rot{{{x}}}" for x in rules_list]))
+RULES_PHASE_2: List[Rule] = []

--- a/prospector/rules/rules_test.py
+++ b/prospector/rules/rules_test.py
@@ -5,12 +5,31 @@ from requests_cache import Optional
 
 from datamodel.advisory import AdvisoryRecord
 from datamodel.commit import Commit
-from rules.rules import apply_rules
+from rules.rules import RULES_PHASE_1, apply_rules
 from util.lsh import get_encoded_minhash
 
 # from datamodel.commit_features import CommitWithFeatures
 
 MOCK_CVE_ID = "CVE-2020-26258"
+
+enabled_rules_from_config = [
+    "VULN_ID_IN_MESSAGE",
+    "XREF_BUG",
+    "XREF_GH",
+    "COMMIT_IN_REFERENCE",
+    "VULN_ID_IN_LINKED_ISSUE",
+    "CHANGES_RELEVANT_FILES",
+    "CHANGES_RELEVANT_CODE",
+    "RELEVANT_WORDS_IN_MESSAGE",
+    "ADV_KEYWORDS_IN_FILES",
+    "ADV_KEYWORDS_IN_MSG",
+    "SEC_KEYWORDS_IN_MESSAGE",
+    "SEC_KEYWORDS_IN_LINKED_GH",
+    "SEC_KEYWORDS_IN_LINKED_BUG",
+    "GITHUB_ISSUE_IN_MESSAGE",
+    "BUG_IN_MESSAGE",
+    "COMMIT_HAS_TWINS",
+]
 
 
 def get_msg(text, limit_length: Optional[int] = None) -> str:
@@ -91,7 +110,9 @@ def advisory_record():
 
 
 def test_apply_phase_1_rules(candidates: List[Commit], advisory_record: AdvisoryRecord):
-    annotated_candidates = apply_rules(candidates, advisory_record, rules=["phase_1"])
+    annotated_candidates = apply_rules(
+        candidates, advisory_record, enabled_rules=enabled_rules_from_config
+    )
 
     # Repo 5: Should match: AdvKeywordsInFiles, SecurityKeywordsInMsg, CommitMentionedInReference
     assert len(annotated_candidates[0].matched_rules) == 3

--- a/prospector/rules/rules_test.py
+++ b/prospector/rules/rules_test.py
@@ -1,38 +1,68 @@
 from typing import List
 
 import pytest
+from requests_cache import Optional
 
 from datamodel.advisory import AdvisoryRecord
 from datamodel.commit import Commit
 from rules.rules import apply_rules
+from util.lsh import get_encoded_minhash
 
 # from datamodel.commit_features import CommitWithFeatures
+
+MOCK_CVE_ID = "CVE-2020-26258"
+
+
+def get_msg(text, limit_length: Optional[int] = None) -> str:
+    return text[:limit_length] if limit_length else text
 
 
 @pytest.fixture
 def candidates():
     return [
+        # Should match: VulnIdInMessage, ReferencesGhIssue
         Commit(
             repository="repo1",
-            commit_id="1",
-            message="Blah blah blah fixes CVE-2020-26258 and a few other issues",
+            commit_id="1234567890",
+            message=f"Blah blah blah fixes {MOCK_CVE_ID} and a few other issues",
             ghissue_refs={"example": ""},
             changed_files={"foo/bar/otherthing.xml", "pom.xml"},
-            cve_refs=["CVE-2020-26258"],
+            cve_refs=[f"{MOCK_CVE_ID}"],
+            minhash=get_encoded_minhash(
+                get_msg(
+                    f"Blah blah blah fixes {MOCK_CVE_ID} and a few other issues",
+                    50,
+                )
+            ),
         ),
-        Commit(repository="repo2", commit_id="2", cve_refs=["CVE-2020-26258"]),
+        Commit(
+            repository="repo2",
+            commit_id="2234567890",
+            message="",
+            minhash=get_encoded_minhash(get_msg("")),
+        ),
+        # Should match: VulnIdInMessage, ReferencesGhIssue
         Commit(
             repository="repo3",
-            commit_id="3",
-            message="Another commit that fixes CVE-2020-26258",
+            commit_id="3234567890",
+            message=f"Another commit that fixes {MOCK_CVE_ID}",
             ghissue_refs={"example": ""},
+            cve_refs=[f"{MOCK_CVE_ID}"],
+            minhash=get_encoded_minhash(
+                get_msg(f"Another commit that fixes {MOCK_CVE_ID}", 50)
+            ),
         ),
+        # Should match: SecurityKeywordsInMsg
         Commit(
             repository="repo4",
-            commit_id="4",
+            commit_id="4234567890",
             message="Endless loop causes DoS vulnerability",
             changed_files={"foo/bar/otherthing.xml", "pom.xml"},
+            minhash=get_encoded_minhash(
+                get_msg("Endless loop causes DoS vulnerability", 50)
+            ),
         ),
+        # Should match: AdvKeywordsInFiles, SecurityKeywordsInMsg, CommitMentionedInReference
         Commit(
             repository="repo5",
             commit_id="7532d2fb0d6081a12c2a48ec854a81a8b718be62",
@@ -40,111 +70,56 @@ def candidates():
             changed_files={
                 "core/src/main/java/org/apache/cxf/workqueue/AutomaticWorkQueueImpl.java"
             },
+            minhash=get_encoded_minhash(get_msg("Insecure deserialization", 50)),
         ),
+        # TODO: Not matched by existing tests: GHSecurityAdvInMessage, ReferencesBug, ChangesRelevantCode, TwinMentionedInAdv, VulnIdInLinkedIssue, SecurityKeywordInLinkedGhIssue, SecurityKeywordInLinkedBug, CrossReferencedBug, CrossReferencedGh, CommitHasTwins, ChangesRelevantFiles, CommitMentionedInAdv, RelevantWordsInMessage
     ]
 
 
 @pytest.fixture
 def advisory_record():
     return AdvisoryRecord(
-        vulnerability_id="CVE-2020-26258",
+        cve_id=f"{MOCK_CVE_ID}",
         repository_url="https://github.com/apache/struts",
         published_timestamp=1607532756,
-        references=["https://reference.to/some/commit/7532d2fb0d60"],
+        references={
+            "https://reference.to/some/commit/7532d2fb0d60": 1,
+        },
         keywords=["AutomaticWorkQueueImpl"],
-        paths=["pom.xml"],
+        # paths=["pom.xml"],
     )
 
 
-def test_apply_rules_all(candidates: List[Commit], advisory_record: AdvisoryRecord):
-    annotated_candidates = apply_rules(candidates, advisory_record)
+def test_apply_phase_1_rules(candidates: List[Commit], advisory_record: AdvisoryRecord):
+    annotated_candidates = apply_rules(candidates, advisory_record, rules=["phase_1"])
 
-    assert len(annotated_candidates[0].matched_rules) == 4
-    assert annotated_candidates[0].matched_rules[0][0] == "CVE_ID_IN_MESSAGE"
-    assert "CVE-2020-26258" in annotated_candidates[0].matched_rules[0][1]
+    # Repo 5: Should match: AdvKeywordsInFiles, SecurityKeywordsInMsg, CommitMentionedInReference
+    assert len(annotated_candidates[0].matched_rules) == 3
 
-    # assert len(annotated_candidates[0].annotations) > 0
-    # assert "REF_ADV_VULN_ID" in annotated_candidates[0].annotations
-    # assert "REF_GH_ISSUE" in annotated_candidates[0].annotations
-    # assert "CH_REL_PATH" in annotated_candidates[0].annotations
+    matched_rules_names = [item["id"] for item in annotated_candidates[0].matched_rules]
+    assert "ADV_KEYWORDS_IN_FILES" in matched_rules_names
+    assert "COMMIT_IN_REFERENCE" in matched_rules_names
+    assert "SEC_KEYWORDS_IN_MESSAGE" in matched_rules_names
 
-    # assert len(annotated_candidates[1].annotations) > 0
-    # assert "REF_ADV_VULN_ID" in annotated_candidates[1].annotations
-    # assert "REF_GH_ISSUE" not in annotated_candidates[1].annotations
-    # assert "CH_REL_PATH" not in annotated_candidates[1].annotations
+    # Repo 1: Should match: VulnIdInMessage, ReferencesGhIssue
+    assert len(annotated_candidates[1].matched_rules) == 2
 
-    # assert len(annotated_candidates[2].annotations) > 0
-    # assert "REF_ADV_VULN_ID" not in annotated_candidates[2].annotations
-    # assert "REF_GH_ISSUE" in annotated_candidates[2].annotations
-    # assert "CH_REL_PATH" not in annotated_candidates[2].annotations
+    matched_rules_names = [item["id"] for item in annotated_candidates[1].matched_rules]
+    assert "VULN_ID_IN_MESSAGE" in matched_rules_names
+    assert "GITHUB_ISSUE_IN_MESSAGE" in matched_rules_names
 
-    # assert len(annotated_candidates[3].annotations) > 0
-    # assert "REF_ADV_VULN_ID" not in annotated_candidates[3].annotations
-    # assert "REF_GH_ISSUE" not in annotated_candidates[3].annotations
-    # assert "CH_REL_PATH" in annotated_candidates[3].annotations
-    # assert "SEC_KEYWORD_IN_COMMIT_MSG" in annotated_candidates[3].annotations
+    # Repo 3: Should match: VulnIdInMessage, ReferencesGhIssue
+    assert len(annotated_candidates[2].matched_rules) == 2
 
-    # assert "SEC_KEYWORD_IN_COMMIT_MSG" in annotated_candidates[4].annotations
-    # assert "TOKENS_IN_MODIFIED_PATHS" in annotated_candidates[4].annotations
-    # assert "COMMIT_MENTIONED_IN_ADV" in annotated_candidates[4].annotations
+    matched_rules_names = [item["id"] for item in annotated_candidates[2].matched_rules]
+    assert "VULN_ID_IN_MESSAGE" in matched_rules_names
+    assert "GITHUB_ISSUE_IN_MESSAGE" in matched_rules_names
 
+    # Repo 4: Should match: SecurityKeywordsInMsg
+    assert len(annotated_candidates[3].matched_rules) == 1
 
-def test_apply_rules_selected(
-    candidates: List[Commit], advisory_record: AdvisoryRecord
-):
-    annotated_candidates = apply_rules(
-        candidates=candidates,
-        advisory_record=advisory_record,
-        rules=[
-            "REF_ADV_VULN_ID",
-            "REF_GH_ISSUE",
-            "CH_REL_PATH",
-            "SEC_KEYWORD_IN_COMMIT_MSG",
-            "TOKENS_IN_MODIFIED_PATHS",
-            "COMMIT_MENTIONED_IN_ADV",
-        ],
-    )
+    matched_rules_names = [item["id"] for item in annotated_candidates[3].matched_rules]
+    assert "SEC_KEYWORDS_IN_MESSAGE" in matched_rules_names
 
-    assert len(annotated_candidates[0].annotations) > 0
-    assert "REF_ADV_VULN_ID" in annotated_candidates[0].annotations
-    assert "REF_GH_ISSUE" in annotated_candidates[0].annotations
-    assert "CH_REL_PATH" in annotated_candidates[0].annotations
-
-    assert len(annotated_candidates[1].annotations) > 0
-    assert "REF_ADV_VULN_ID" in annotated_candidates[1].annotations
-    assert "REF_GH_ISSUE" not in annotated_candidates[1].annotations
-    assert "CH_REL_PATH" not in annotated_candidates[1].annotations
-
-    assert len(annotated_candidates[2].annotations) > 0
-    assert "REF_ADV_VULN_ID" not in annotated_candidates[2].annotations
-    assert "REF_GH_ISSUE" in annotated_candidates[2].annotations
-    assert "CH_REL_PATH" not in annotated_candidates[2].annotations
-
-    assert len(annotated_candidates[3].annotations) > 0
-    assert "REF_ADV_VULN_ID" not in annotated_candidates[3].annotations
-    assert "REF_GH_ISSUE" not in annotated_candidates[3].annotations
-    assert "CH_REL_PATH" in annotated_candidates[3].annotations
-    assert "SEC_KEYWORD_IN_COMMIT_MSG" in annotated_candidates[3].annotations
-
-    assert "SEC_KEYWORD_IN_COMMIT_MSG" in annotated_candidates[4].annotations
-    assert "TOKENS_IN_MODIFIED_PATHS" in annotated_candidates[4].annotations
-    assert "COMMIT_MENTIONED_IN_ADV" in annotated_candidates[4].annotations
-
-
-def test_apply_rules_selected_rules(
-    candidates: List[Commit], advisory_record: AdvisoryRecord
-):
-    annotated_candidates = apply_rules(
-        candidates=candidates,
-        advisory_record=advisory_record,
-        rules=["ALL", "-REF_ADV_VULN_ID"],
-    )
-
-    assert len(annotated_candidates[0].annotations) > 0
-    assert "REF_ADV_VULN_ID" not in annotated_candidates[0].annotations
-    assert "REF_GH_ISSUE" in annotated_candidates[0].annotations
-    assert "CH_REL_PATH" in annotated_candidates[0].annotations
-
-
-def test_sec_keywords_in_linked_issue():
-    print("TODO")
+    # Repo 2: Matches nothing
+    assert len(annotated_candidates[4].matched_rules) == 0

--- a/prospector/stats/collection.py
+++ b/prospector/stats/collection.py
@@ -8,6 +8,8 @@ from util.type_safety import is_instance_of_either
 
 
 class ForbiddenDuplication(ValueError):
+    """Custom Error for Collections"""
+
     ...
 
 
@@ -54,6 +56,10 @@ def _summarize_list(collection, unit: Optional[str] = None):
 
 
 class StatisticCollection(dict):
+    """The StatisticCollection can contain nested sub-collections, and each entry in the
+    collection can hold a list of values along with an optional unit.
+    """
+
     def __init__(self):
         super().__init__()
         self.units = {}

--- a/prospector/util/config_parser.py
+++ b/prospector/util/config_parser.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import sys
 from dataclasses import MISSING, dataclass
-from typing import Optional
+from typing import List, Optional
 
 from omegaconf import OmegaConf
 from omegaconf.errors import (
@@ -199,6 +199,7 @@ class ConfigSchema:
     report: ReportConfig = MISSING
     log_level: str = MISSING
     git_cache: str = MISSING
+    enabled_rules: List[str] = MISSING
     nvd_token: Optional[str] = None
     database: DatabaseConfig = DatabaseConfig(
         user="postgres", password="example", host="db", port=5432, dbname="postgres"
@@ -232,6 +233,7 @@ class Config:
         ping: bool,
         log_level: str,
         git_cache: str,
+        enabled_rules: List[str],
         ignore_refs: bool,
         llm_service: LLMServiceConfig,
     ):
@@ -256,6 +258,7 @@ class Config:
         self.ping = ping
         self.log_level = log_level
         self.git_cache = git_cache
+        self.enabled_rules = enabled_rules
         self.ignore_refs = ignore_refs
 
 
@@ -291,6 +294,7 @@ def get_configuration(argv):
             report_filename=args.report_filename or conf.report.name,
             ping=args.ping,
             git_cache=conf.git_cache,
+            enabled_rules=conf.enabled_rules,
             log_level=args.log_level or conf.log_level,
             ignore_refs=args.ignore_refs,
         )


### PR DESCRIPTION
1. A set of rules to apply can now be selected in config.yaml. Initially, it is set to all rules except the ones requiring llm_service (Phase 2 rules).
2. Rules are now applied in phases. All original Prospector rules are applied in "Phase 1" to all commits. Phase 2 applies its rules only to a subset of the ranked commits from Phase 1.