### PR TITLE
Remove missing commits from 7 CVEs

### DIFF
--- a/statements/CVE-2011-4343/statement.yaml
+++ b/statements/CVE-2011-4343/statement.yaml
@@ -6,10 +6,6 @@ fixes:
   commits:
   - id: ed925077332275b5cd652410f438bb4893566fb8
     repository: https://github.com/apache/myfaces
-- id: 2.0.x
-  commits:
-  - id: f4e8981e4b17cc1ee9d3c79f6cd34f7bb2201f7
-    repository: https://github.com/apache/myfaces
 artifacts:
 - id: pkg:maven/javax/javaee-api@6.0
   reason: Reviewed manually

--- a/statements/CVE-2014-4172/statement.yaml
+++ b/statements/CVE-2014-4172/statement.yaml
@@ -1,13 +1,6 @@
 vulnerability_id: CVE-2014-4172
 notes:
 - text: A URL parameter injection vulnerability was found in the back-channel ticket validation step of the CAS protocol in Jasig Java CAS Client before 3.3.2, .NET CAS Client before 1.0.2, and phpCAS before 1.3.3 that allow remote attackers to inject arbitrary web script or HTML via the (1) service parameter to validation/AbstractUrlBasedTicketValidator.java or (2) pgtUrl parameter to validation/Cas20ServiceTicketValidator.java.
-fixes:
-- id: DEFAULT_BRANCH
-  commits:
-  - id: ab6cbdc3daa451b4fef89c0bd0f4e6568f3aa9ef
-    repository: https://github.com/apereo/java-cas-client
-  - id: ae37092100c8eaec610dab6d83e5e05a8ee58814
-    repository: https://github.com/apereo/java-cas-client
 artifacts:
 - id: pkg:maven/org.jasig.cas.client/cas-client-core@3.5.0
   reason: Assessed with Eclipse Steady (AST_EQUALITY)

--- a/statements/CVE-2016-2141/statement.yaml
+++ b/statements/CVE-2016-2141/statement.yaml
@@ -6,10 +6,6 @@ fixes:
   commits:
   - id: 38a882331035ffed205d15a5c92b471fd09659c
     repository: https://github.com/belaban/JGroups
-- id: 2.6.22
-  commits:
-  - id: c3ad22234ef84d06d04d908b3c94c0d11df8afd
-    repository: https://github.com/belaban/JGroups
 - id: 3.6.10
   commits:
   - id: fba182c14075789e1d2c976d50d9018c671ad0b

--- a/statements/CVE-2016-2510/statement.yaml
+++ b/statements/CVE-2016-2510/statement.yaml
@@ -1,13 +1,6 @@
 vulnerability_id: CVE-2016-2510
 notes:
 - text: BeanShell (bsh) before 2.0b6, when included on the classpath by an application that uses Java serialization or XStream, allows remote attackers to execute arbitrary code via crafted serialized data, related to XThis.Handler.
-fixes:
-- id: DEFAULT_BRANCH
-  commits:
-  - id: 1ccc66bb693d4e46a34a904db8eeff07808d2ced
-    repository: https://github.com/beanshell/beanshell
-  - id: 7c68fde2d6fc65e362f20863d868c112a90a9b49
-    repository: https://github.com/beanshell/beanshell
 artifacts:
 - id: pkg:maven/org.beanshell/bsh@1.3.0
   reason: Reviewed manually

--- a/statements/CVE-2017-12626/statement.yaml
+++ b/statements/CVE-2017-12626/statement.yaml
@@ -1,17 +1,6 @@
 vulnerability_id: CVE-2017-12626
 notes:
 - text: 'Apache POI in versions prior to release 3.17 are vulnerable to Denial of Service Attacks: 1) Infinite Loops while parsing crafted WMF, EMF, MSG and macros (POI bugs 61338 and 61294), and 2) Out of Memory Exceptions while parsing crafted DOC, PPT and XLS (POI bugs 52372 and 61295).'
-fixes:
-- id: DEFAULT_BRANCH
-  commits:
-  - id: c7db66a30dfb6cbbd5812ff3ae4c90ed2d9b9a27
-    repository: https://github.com/apache/poi
-  - id: cd6236c74b55763a27e3e9b5f269c28bc9c98419
-    repository: https://github.com/apache/poi
-  - id: df3910135fd9c442b4e746e4b156362fd2e8d755
-    repository: https://github.com/apache/poi
-  - id: a07ed9e86474da98f204efadfd5b9327009a0d21
-    repository: https://github.com/apache/poi
 artifacts:
 - id: pkg:maven/org.apache.poi/poi-scratchpad@4.0.0
   reason: Assessed with Eclipse Steady (AST_EQUALITY)

--- a/statements/CVE-2017-5644/statement.yaml
+++ b/statements/CVE-2017-5644/statement.yaml
@@ -1,11 +1,6 @@
 vulnerability_id: CVE-2017-5644
 notes:
 - text: Apache POI in versions prior to release 3.15 allows remote attackers to cause a denial of service (CPU consumption) via a specially crafted OOXML file, aka an XML Entity Expansion (XEE) attack.
-fixes:
-- id: DEFAULT_BRANCH
-  commits:
-  - id: 3a328aa220f6979f9805f658ae33244d153beaa7
-    repository: https://github.com/apache/poi
 artifacts:
 - id: pkg:maven/org.apache.poi/poi-ooxml@3.13-beta1
   reason: Assessed with Eclipse Steady (AST_EQUALITY)

--- a/statements/CVE-2019-17359/statement.yaml
+++ b/statements/CVE-2019-17359/statement.yaml
@@ -1,13 +1,6 @@
 vulnerability_id: CVE-2019-17359
 notes:
 - text: The ASN.1 parser in Bouncy Castle Crypto (aka BC Java) 1.63 can trigger a large attempted memory allocation, and resultant OutOfMemoryError error, via crafted ASN.1 data. This is fixed in 1.64.
-fixes:
-- id: DEFAULT_BRANCH
-  commits:
-  - id: 33a8e4aa07b21a8bcf5a582446664485f5f081b2
-    repository: https://github.com/bcgit/bc-java
-  - id: b1bc75254f5fea633a49a751a1a7339056f97856
-    repository: https://github.com/bcgit/bc-java
 artifacts:
 - id: pkg:maven/org.bouncycastle/bcprov-jdk15on@1.54
   reason: Assessed with Eclipse Steady (AST_EQUALITY)


### PR DESCRIPTION
For the following 7 CVEs either commits or even the full branch of the commits are missing:

- CVE-2011-4343
- CVE-2014-4172
- CVE-2016-2141
- CVE-2016-2510
- CVE-2017-12626
- CVE-2017-5644