### PR TITLE
Separate commits that are not on the same branch into different fix IDs.

### DIFF
--- a/statements/CVE-2014-0225/statement.yaml
+++ b/statements/CVE-2014-0225/statement.yaml
@@ -6,6 +6,8 @@ fixes:
   commits:
   - id: 8e096aeef55287dc829484996c9330cf755891a1
     repository: https://github.com/spring-projects/spring-framework.git
+- id: 3.2.x
+  commits:    
   - id: c6503ebbf7c9e21ff022c58706dbac5417b2b5eb
     repository: https://github.com/spring-projects/spring-framework.git
 artifacts:

--- a/statements/CVE-2014-1904/statement.yaml
+++ b/statements/CVE-2014-1904/statement.yaml
@@ -6,6 +6,8 @@ fixes:
   commits:
   - id: 741b4b229ae032bd17175b46f98673ce0bd2d485
     repository: https://github.com/spring-projects/spring-framework.git
+- id: 3.2.x
+  commits:    
   - id: 75e08695a04980dbceae6789364717e9d8764d58
     repository: https://github.com/spring-projects/spring-framework.git
 artifacts:

--- a/statements/CVE-2014-3625/statement.yaml
+++ b/statements/CVE-2014-3625/statement.yaml
@@ -2,12 +2,16 @@ vulnerability_id: CVE-2014-3625
 notes:
 - text: Directory traversal vulnerability in Pivotal Spring Framework 3.0.4 through 3.2.x before 3.2.12, 4.0.x before 4.0.8, and 4.1.x before 4.1.2 allows remote attackers to read arbitrary files via unspecified vectors, related to static resource handling.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 3.2.x
   commits:
   - id: 3f68cd633f03370d33c2603a6496e81273782601
     repository: https://github.com/spring-projects/spring-framework.git
+- id: 4.0.x
+  commits:    
   - id: 9beae9ae4226c45cd428035dae81214439324676
     repository: https://github.com/spring-projects/spring-framework.git
+- id: DEFAULT_BRANCH
+  commits:
   - id: 9cef8e3001ddd61c734281a7556efd84b6cc2755
     repository: https://github.com/spring-projects/spring-framework.git
 artifacts:

--- a/statements/CVE-2015-5175/statement.yaml
+++ b/statements/CVE-2015-5175/statement.yaml
@@ -2,9 +2,11 @@ vulnerability_id: CVE-2015-5175
 notes:
 - text: Application plugins in Apache CXF Fediz before 1.1.3 and 1.2.x before 1.2.1 allow remote attackers to cause a denial of service.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 1.2.x-fixes
   commits:
   - id: 90c898335786211d253c0503453e2f8b93e0d3fe
     repository: https://github.com/apache/cxf-fediz.git
+- id: DEFAULT_BRANCH
+  commits:
   - id: f65c961ea31e3c1851daba8e7e49fc37bbf77b19
     repository: https://github.com/apache/cxf-fediz.git

--- a/statements/CVE-2015-5348/statement.yaml
+++ b/statements/CVE-2015-5348/statement.yaml
@@ -2,7 +2,7 @@ vulnerability_id: CVE-2015-5348
 notes:
 - text: Apache Camel 2.6.x through 2.14.x, 2.15.x before 2.15.5, and 2.16.x before 2.16.1, when using (1) camel-jetty or (2) camel-servlet as a consumer in Camel routes, allow remote attackers to execute arbitrary commands via a crafted serialized Java object in an HTTP request.
 fixes:
-- id: DEFAULT_BRANCH
+- id: camel-2.16.x
   commits:
   - id: c703479f5880a099c38f2fd5e63c7d9f0567e5ff
     repository: https://github.com/apache/camel
@@ -12,35 +12,25 @@ fixes:
     repository: https://github.com/apache/camel
   - id: 92081b203523c5ed502ed41df43cbd8655caf9b9
     repository: https://github.com/apache/camel
+  - id: d853853469292cd54fd9662c3605030ab5a9566b
+    repository: https://github.com/apache/camel
+  - id: c558f30a6d3820faa3d8c4ad5e54448914ec60d0
+    repository: https://github.com/apache/camel
+  - id: 515c822148d52de9e7cdf4f6b01f7b793f2f273f
+    repository: https://github.com/apache/camel
+- id: camel-2.15.x
+  commits:
   - id: 9cbd5867fe73ef07ecba6f16d64689632e3f2a16
     repository: https://github.com/apache/camel
-  - id: f7f0b18f6924fe0b01f32a25ed1e38e29b1bf8e5
-    repository: https://github.com/apache/camel
   - id: 190d7c81b7e3ce767514e319630b1bbaf27e6817
-    repository: https://github.com/apache/camel
-  - id: d853853469292cd54fd9662c3605030ab5a9566b
     repository: https://github.com/apache/camel
   - id: e7fd5f049c2fd51a528f8062da91a1c75e33b0e8
     repository: https://github.com/apache/camel
   - id: ec4a48d38e7335b40efcb14979fad8144eb00acf
     repository: https://github.com/apache/camel
-  - id: 94330f99acb6f28155793b253de9956c3798f3bb
-    repository: https://github.com/apache/camel
-  - id: a68434c258cdcd30587ae7adc5dabbac43eadbbf
-    repository: https://github.com/apache/camel
-  - id: c558f30a6d3820faa3d8c4ad5e54448914ec60d0
-    repository: https://github.com/apache/camel
-  - id: 0afcf721ff209eb10a24c5e4b48ca9d6727ea99a
-    repository: https://github.com/apache/camel
   - id: 23655fe0c15189ca41a6e99c31a3c38001a7cdb0
     repository: https://github.com/apache/camel
   - id: 349109b0834764560f0be69eb74f43a16bd220b0
-    repository: https://github.com/apache/camel
-  - id: 7e28d0af471ea992eb74807a4abd1626b88d678a
-    repository: https://github.com/apache/camel
-  - id: 5ea0a6f6c6a54f1cddf9691a99b0c237afc95348
-    repository: https://github.com/apache/camel
-  - id: c47cffcadabca0c588753555a386942184a33627
     repository: https://github.com/apache/camel
   - id: 13e43c1412ad72d99030b4eb4cb72c84fa57d5ff
     repository: https://github.com/apache/camel
@@ -48,7 +38,21 @@ fixes:
     repository: https://github.com/apache/camel
   - id: 4f065fe07c1dcd7b451e6005a6dc8e96d77da43e
     repository: https://github.com/apache/camel
-  - id: 515c822148d52de9e7cdf4f6b01f7b793f2f273f
+- id: DEFAULT_BRANCH
+  commits:
+  - id: f7f0b18f6924fe0b01f32a25ed1e38e29b1bf8e5
+    repository: https://github.com/apache/camel
+  - id: 94330f99acb6f28155793b253de9956c3798f3bb
+    repository: https://github.com/apache/camel
+  - id: a68434c258cdcd30587ae7adc5dabbac43eadbbf
+    repository: https://github.com/apache/camel
+  - id: 0afcf721ff209eb10a24c5e4b48ca9d6727ea99a
+    repository: https://github.com/apache/camel
+  - id: 7e28d0af471ea992eb74807a4abd1626b88d678a
+    repository: https://github.com/apache/camel
+  - id: 5ea0a6f6c6a54f1cddf9691a99b0c237afc95348
+    repository: https://github.com/apache/camel
+  - id: c47cffcadabca0c588753555a386942184a33627
     repository: https://github.com/apache/camel
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-http@2.21.5

--- a/statements/CVE-2017-12174/statement.yaml
+++ b/statements/CVE-2017-12174/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2017-12174
 notes:
 - text: It was found that when Artemis and HornetQ before 2.4.0 are configured with UDP discovery and JGroups discovery a huge byte array is created when receiving an unexpected multicast message. This may result in a heap memory exhaustion, full GC, or OutOfMemoryError.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 1.5.6
   commits:
   - id: 0f081e96a504a87a674a873e91e49e7a258216e
     repository: https://github.com/apache/activemq-artemis
+- id: DEFAULT_BRANCH
+  commits:
   - id: 76b1f9cf8faa4797122ac71273b507bf146e1c0
     repository: https://github.com/apache/activemq-artemis
 artifacts:

--- a/statements/CVE-2017-12612/statement.yaml
+++ b/statements/CVE-2017-12612/statement.yaml
@@ -2,10 +2,6 @@ vulnerability_id: CVE-2017-12612
 notes:
 - text: In Apache Spark 1.6.0 until 2.1.1, the launcher API performs unsafe deserialization of data received by its socket. This makes applications launched programmatically using the launcher API potentially vulnerable to arbitrary code execution by an attacker with access to any user account on the local machine. It does not affect apps run by spark-submit or spark-shell. The attacker would be able to execute code as the user that ran the Spark application. Users are encouraged to update to version 2.2.0 or later.
 fixes:
-- id: 2.3.x
-  commits:
-  - id: 8efc6e986554ae66eab93cd64a9035d716adbab
-    repository: https://github.com/apache/spark
 - id: 2.0.x
   commits:
   - id: f7cbf90a72a19476ea2d3d1ddc96c45a24b9f57
@@ -18,11 +14,17 @@ fixes:
   commits:
   - id: 4cba3b5a350f4d477466fc73b32cbd653eee840
     repository: https://github.com/apache/spark
-- id: DEFAULT_BRANCH
+- id: branch-2.1
   commits:
   - id: 772a9b969aa179150aa216e9efd950e512e9d0b4
     repository: https://github.com/apache/spark
+- id: branch-2.0
+  commits:
   - id: 9952b53b57498852cba799b47f00238e52114c7c
+    repository: https://github.com/apache/spark
+- id: 2.3.x
+  commits:
+  - id: 8efc6e986554ae66eab93cd64a9035d716adbab
     repository: https://github.com/apache/spark
 artifacts:
 - id: pkg:maven/org.apache.spark/spark-launcher_2.11@2.4.5

--- a/statements/CVE-2017-7561/statement.yaml
+++ b/statements/CVE-2017-7561/statement.yaml
@@ -6,8 +6,12 @@ fixes:
   commits:
   - id: 517db971d8f7094124416bf72091fd0b45a1302
     repository: https://github.com/resteasy/Resteasy
+- id: 3.0.19.SPx
+  commits:
   - id: e9a34f2513e75dcaba95e1f2bc6f21668f43985
     repository: https://github.com/resteasy/Resteasy
+- id: 3.0
+  commits:
   - id: fd66aad3cb1e8553323a9af5b58f1ad5150dc5b
     repository: https://github.com/resteasy/Resteasy
 artifacts:

--- a/statements/CVE-2018-11768/statement.yaml
+++ b/statements/CVE-2018-11768/statement.yaml
@@ -2,12 +2,16 @@ vulnerability_id: CVE-2018-11768
 notes:
 - text: In Apache Hadoop 3.1.0 to 3.1.1, 3.0.0-alpha1 to 3.0.3, 2.9.0 to 2.9.1, and 2.0.0-alpha to 2.8.4, the user/group information can be corrupted across storing in fsimage and reading back from fsimage.
 fixes:
-- id: DEFAULT_BRANCH
+- id: branch-2.9
   commits:
   - id: eeeea1d75d69d4619955e6b5ab5a7db18ee252b
     repository: https://github.com/apache/hadoop
+- id: branch-3.1
+  commits:
   - id: 96cedb87b94c07c11152580bf36978186d622b5
     repository: https://github.com/apache/hadoop
+- id: branch-2.8
+  commits:    
   - id: a868fb1c8fab1be927654b453b2eb9d98cb3066
     repository: https://github.com/apache/hadoop
 artifacts:

--- a/statements/CVE-2018-1271/statement.yaml
+++ b/statements/CVE-2018-1271/statement.yaml
@@ -2,7 +2,7 @@ vulnerability_id: CVE-2018-1271
 notes:
 - text: Spring Framework, versions 5.0 prior to 5.0.5 and versions 4.3 prior to 4.3.15 and older unsupported versions, allow applications to configure Spring MVC to serve static resources (e.g. CSS, JS, images). When static resources are served from a file system on Windows (as opposed to the classpath, or the ServletContext), a malicious user can send a request using a specially crafted URL that can lead a directory traversal attack.
 fixes:
-- id: 5.0.5
+- id: DEFAULT_BRANCH
   commits:
   - id: 98ad23bef8e2e04143f8f5b201380543a8d8c0c
     repository: https://github.com/spring-projects/spring-framework
@@ -14,8 +14,6 @@ fixes:
     repository: https://github.com/spring-projects/spring-framework
   - id: 91b803a2310344d925e5d4b1709bbcea9037554
     repository: https://github.com/spring-projects/spring-framework
-- id: "5.05"
-  commits:
   - id: 695bf2961feffd35b5560ccc982a2189dcca611
     repository: https://github.com/spring-projects/spring-framework
 - id: 4.3.x

--- a/statements/CVE-2019-12399/statement.yaml
+++ b/statements/CVE-2019-12399/statement.yaml
@@ -2,14 +2,20 @@ vulnerability_id: CVE-2019-12399
 notes:
 - text: When Connect workers in Apache Kafka 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.2.0, 2.2.1, or 2.3.0 are configured with one or more config providers, and a connector is created/updated on that Connect cluster to use an externalized secret variable in a substring of a connector configuration property value, then any client can issue a request to the same Connect cluster to obtain the connector's task configuration and the response will contain the plaintext secret rather than the externalized secrets variables.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 2.2
   commits:
   - id: 5d2a6dc531150423a40f77783a4a09e1b0f9017
     repository: https://github.com/apache/kafka
+- id: 2.0
+  commits:
   - id: 921937ba3b897b9a16b806bab2111362064ff83
     repository: https://github.com/apache/kafka
+- id: 2.3
+  commits:
   - id: b85707c0fdb4c11448cdb5a1938e0488ddc9110
     repository: https://github.com/apache/kafka
+- id: 2.1
+  commits:
   - id: e20bc24909c22875d17c4a90d1d0c9c6608001b
     repository: https://github.com/apache/kafka
 artifacts:

--- a/statements/CVE-2019-12406/statement.yaml
+++ b/statements/CVE-2019-12406/statement.yaml
@@ -6,6 +6,8 @@ fixes:
   commits:
   - id: 6c3990144b56097502aa9f3ec9c06f303110902
     repository: https://github.com/apache/cxf
+- id: 3.3.x-fixes
+  commits:
   - id: fd85803a73ad46f36816bcb55ed1c4f4b4c4312
     repository: https://github.com/apache/cxf
 artifacts:

--- a/statements/CVE-2019-12419/statement.yaml
+++ b/statements/CVE-2019-12419/statement.yaml
@@ -2,12 +2,16 @@ vulnerability_id: CVE-2019-12419
 notes:
 - text: Apache CXF before 3.3.4 and 3.2.11 provides all of the components that are required to build a fully fledged OpenId Connect service. There is a vulnerability in the access token services, where it does not validate that the authenticated principal is equal to that of the supplied clientId parameter in the request. If a malicious client was able to somehow steal an authorization code issued to another client, then they could exploit this vulnerability to obtain an access token for the other client.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 3.3.x-fixes
   commits:
   - id: 6bf89927d3e07197d49453b00d673eadce696cf
     repository: https://github.com/apache/cxf
+- id: 3.2.x-fixes
+  commits:
   - id: db6069667708a59c75a785f310d4a2df3698122
     repository: https://github.com/apache/cxf
+- id: DEFAULT_BRANCH
+  commits:
   - id: 337609d81a9f53e7680cb79d9ab733a79f4cd76
     repository: https://github.com/apache/cxf
 artifacts:

--- a/statements/CVE-2019-12423/statement.yaml
+++ b/statements/CVE-2019-12423/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2019-12423
 notes:
 - text: Apache CXF ships with a OpenId Connect JWK Keys service, which allows a client to obtain the public keys in JWK format, which can then be used to verify the signature of tokens issued by the service. Typically, the service obtains the public key from a local keystore (JKS/PKCS12) by specifing the path of the keystore and the alias of the keystore entry. This case is not vulnerable. However it is also possible to obtain the keys from a JWK keystore file, by setting the configuration parameter "rs.security.keystore.type" to "jwk". For this case all keys are returned in this file "as is", including all private key and secret key credentials. This is an obvious security risk if the user has configured the signature keystore file with private or secret key credentials. From CXF 3.3.5 and 3.2.12, it is mandatory to specify an alias corresponding to the id of the key in the JWK file, and only this key is returned. In addition, any private key information is omitted by default. "oct" keys, which contain secret keys, are not returned at all.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 3.3.x-fixes
   commits:
   - id: 2de7e14eb95626fffef6f61365186de9a1c9de3
     repository: https://github.com/apache/cxf
+- id: 3.2.x-fixes
+  commits:
   - id: 8b40fdba289c62f4defae51c1f76860f0159c44
     repository: https://github.com/apache/cxf
 artifacts:

--- a/statements/CVE-2019-16869/statement.yaml
+++ b/statements/CVE-2019-16869/statement.yaml
@@ -6,6 +6,8 @@ fixes:
   commits:
   - id: 017a9658c97ff1a1355c31a6a1f8bd1ea6f21c8
     repository: https://github.com/netty/netty
+- id: 4.1
+  commits:
   - id: 39cafcb05c99f2aa9fce7e6597664c9ed6a63a9
     repository: https://github.com/netty/netty
 artifacts:

--- a/statements/CVE-2019-17573/statement.yaml
+++ b/statements/CVE-2019-17573/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2019-17573
 notes:
 - text: By default, Apache CXF creates a /services page containing a listing of the available endpoint names and addresses. This webpage is vulnerable to a reflected Cross-Site Scripting (XSS) attack, which allows a malicious actor to inject javascript into the web page. Please note that the attack exploits a feature which is not typically not present in modern browsers, who remove dot segments before sending the request. However, Mobile applications may be vulnerable.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 3.3.x-fixes
   commits:
   - id: a02e96ba1095596bef481919f16a90c5e80a92c
     repository: https://github.com/apache/cxf
+- id: 3.2.x-fixes
+  commits:
   - id: ffee603ae648c25f6ce5aa01b92c3aa57ebd568
     repository: https://github.com/apache/cxf
 artifacts:

--- a/statements/CVE-2020-11002/statement.yaml
+++ b/statements/CVE-2020-11002/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2020-11002
 notes:
 - text: dropwizard-validation before versions 2.0.3 and 1.3.21 has a remote code execution vulnerability. A server-side template injection was identified in the self-validating feature enabling attackers to inject arbitrary Java EL expressions, leading to Remote Code Execution (RCE) vulnerability. If you are using a self-validating bean an upgrade to Dropwizard 1.3.21/2.0.3 or later is strongly recommended. The changes introduced in Dropwizard 1.3.19 and 2.0.2 for CVE-2020-5245 unfortunately did not fix the underlying issue completely. The issue has been fixed in dropwizard-validation 1.3.21 and 2.0.3 or later. We strongly recommend upgrading to one of these versions.
 fixes:
-- id: DEFAULT_BRANCH
+- id: release/1.3.x
   commits:
   - id: 74e211514db951a67b0e9ff75b0102704d4b204
     repository: https://github.com/dropwizard/dropwizard
+- id: release/4.0.x
+  commits:
   - id: d5a512f7abf965275f2a6b913ac4fe778e42424
     repository: https://github.com/dropwizard/dropwizard
 artifacts:

--- a/statements/CVE-2020-11057/statement.yaml
+++ b/statements/CVE-2020-11057/statement.yaml
@@ -2,11 +2,15 @@ vulnerability_id: CVE-2020-11057
 notes:
 - text: In XWiki Platform 7.2 through 11.10.2, registered users without scripting/programming permissions are able to execute python/groovy scripts while editing personal dashboards. This has been fixed 11.3.7 , 11.10.3 and 12.0.
 fixes:
-- id: DEFAULT_BRANCH
+- id: xwiki-platform-11.10.13
   commits:
   - id: 6d0c3283264cb03c649425b1ef26b007296c4b5
     repository: https://github.com/xwiki/xwiki-platform
+- id: DEFAULT_BRANCH
+  commits:
   - id: 86db078bf1ae3eb49ba5308f55bf3f9a3864e91
     repository: https://github.com/xwiki/xwiki-platform
+- id: xwiki-platform-11.3.7
+  commits:
   - id: dc0fa65fa1c55360dd428106ded5934e7caa59b
     repository: https://github.com/xwiki/xwiki-platform

--- a/statements/CVE-2020-11969/statement.yaml
+++ b/statements/CVE-2020-11969/statement.yaml
@@ -6,8 +6,12 @@ fixes:
   commits:
   - id: 17168ad95e35f1758e16364c2398dea10a4034d
     repository: https://github.com/apache/tomee
+- id: tomee-7.1.x
+  commits:
   - id: 5db25b2850b7bd29d3311c623c7ee2ed5cbb574
     repository: https://github.com/apache/tomee
+- id: tomee-7.0.x
+  commits:
   - id: 6e4c385b9a675c853a539c6b4a0b4d8d9be190c
     repository: https://github.com/apache/tomee
 artifacts:

--- a/statements/CVE-2020-11972/statement.yaml
+++ b/statements/CVE-2020-11972/statement.yaml
@@ -2,14 +2,20 @@ vulnerability_id: CVE-2020-11972
 notes:
 - text: Apache Camel RabbitMQ enables Java deserialization by default. Apache Camel 2.22.x, 2.23.x, 2.24.x, 2.25.0, 3.0.0 up to 3.1.0 are affected. 2.x users should upgrade to 2.25.1, 3.x users should upgrade to 3.2.0.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 3.0.x
   commits:
   - id: 26f7d74755c436513719147f6bafb6f06c655a9
     repository: https://github.com/apache/camel
+- id: DEFAULT_BRANCH
+  commits:
   - id: 7c8a2785b11e705cb5445fde1cebd3eff3d53b1
     repository: https://github.com/apache/camel
+- id: camel-2.25.x
+  commits:
   - id: 94b2c15247c83f233e4dd7870a526113ead9476
     repository: https://github.com/apache/camel
+- id: 3.1.x
+  commits:
   - id: c7d6a6bfd8d9bf2ee17a7d40897b1ce4574f410
     repository: https://github.com/apache/camel
 artifacts:

--- a/statements/CVE-2020-11975/statement.yaml
+++ b/statements/CVE-2020-11975/statement.yaml
@@ -2,11 +2,15 @@ vulnerability_id: CVE-2020-11975
 notes:
 - text: Apache Unomi allows conditions to use OGNL scripting which offers the possibility to call static Java classes from the JDK that could execute code with the permission level of the running Java process.
 fixes:
-- id: DEFAULT_BRANCH
+- id: unomi-1.x
   commits:
   - id: 823386ab117d231df15eab4cb4b7a98f8af546c
     repository: https://github.com/apache/unomi
+- id: unomi-1.4.x
+  commits:
   - id: 3d15022e4b52a2fcc0912ef6c259c3905d4f374
     repository: https://github.com/apache/unomi
+- id: DEFAULT_BRANCH
+  commits:
   - id: 789ae8e820c507866b9c91590feebffa4e996f5
     repository: https://github.com/apache/unomi

--- a/statements/CVE-2020-11980/statement.yaml
+++ b/statements/CVE-2020-11980/statement.yaml
@@ -6,5 +6,7 @@ fixes:
   commits:
   - id: 3e4c4bed2d08e81ca5961ab5fcadab23470db1c
     repository: https://github.com/apache/karaf
+- id: karaf-4.2.x
+  commits:
   - id: 2ccfba48bdfac6c2cd09c8f058641da0011e4c7
     repository: https://github.com/apache/karaf

--- a/statements/CVE-2020-13920/statement.yaml
+++ b/statements/CVE-2020-13920/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2020-13920
 notes:
 - text: Apache ActiveMQ uses LocateRegistry.createRegistry() to create the JMX RMI registry and binds the server to the "jmxrmi" entry. It is possible to connect to the registry without authentication and call the rebind method to rebind jmxrmi to something else. If an attacker creates another server to proxy the original, and bound that, he effectively becomes a man in the middle and is able to intercept the credentials when an user connects. Upgrade to Apache ActiveMQ 5.15.12.
 fixes:
-- id: DEFAULT_BRANCH
+- id: activemq-5.15.x
   commits:
   - id: 48cd61dda07c1ef212d0e9dce5a4398983faf79
     repository: https://github.com/apache/activemq
+- id: DEFAULT_BRANCH
+  commits:
   - id: 58382283330f7c7b110c7afd8ef4ca264878653
     repository: https://github.com/apache/activemq
 artifacts:

--- a/statements/CVE-2020-1937/statement.yaml
+++ b/statements/CVE-2020-1937/statement.yaml
@@ -2,9 +2,11 @@ vulnerability_id: CVE-2020-1937
 notes:
 - text: Kylin has some restful apis which will concatenate SQLs with the user input string, a user is likely to be able to run malicious database queries.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 2.6.x
   commits:
   - id: 1f9f44ceb818b46518176e81c6dea5a0d12750c
     repository: https://github.com/apache/kylin
+- id: 3.0.x
+  commits:
   - id: e373c64c96a54a7abfe4bccb82e8feb60db0474
     repository: https://github.com/apache/kylin

--- a/statements/CVE-2020-1938/statement.yaml
+++ b/statements/CVE-2020-1938/statement.yaml
@@ -2,37 +2,29 @@ vulnerability_id: CVE-2020-1938
 notes:
 - text: 'When using the Apache JServ Protocol (AJP), care must be taken when trusting incoming connections to Apache Tomcat. Tomcat treats AJP connections as having higher trust than, for example, a similar HTTP connection. If such connections are available to an attacker, they can be exploited in ways that may be surprising. In Apache Tomcat 9.0.0.M1 to 9.0.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99, Tomcat shipped with an AJP Connector enabled by default that listened on all configured IP addresses. It was expected (and recommended in the security guide) that this Connector would be disabled if not required. This vulnerability report identified a mechanism that allowed: - returning arbitrary files from anywhere in the web application - processing any file in the web application as a JSP Further, if the web application allowed file upload and stored those files within the web application (or the attacker was able to control the content of the web application by some other means) then this, along with the ability to process a file as a JSP, made remote code execution possible. It is important to note that mitigation is only required if an AJP port is accessible to untrusted users. Users wishing to take a defence-in-depth approach and block the vector that permits returning arbitrary files and execution as JSP may upgrade to Apache Tomcat 9.0.31, 8.5.51 or 7.0.100 or later. A number of changes were made to the default AJP Connector configuration in 9.0.31 to harden the default configuration. It is likely that users upgrading to 9.0.31, 8.5.51 or 7.0.100 or later will need to make small changes to their configurations.'
 fixes:
-- id: DEFAULT_BRANCH
+- id: 7.0.x
   commits:
   - id: 0d633e
     repository: https://github.com/apache/tomcat
-  - id: 49ad3f
+  - id: 40d5d9
     repository: https://github.com/apache/tomcat
-  - id: f7180b
-    repository: https://github.com/apache/tomcat
+- id: 8.5.x
+  commits:
   - id: b96283
-    repository: https://github.com/apache/tomcat
-  - id: 64fa5b
     repository: https://github.com/apache/tomcat
   - id: 69c560
     repository: https://github.com/apache/tomcat
-  - id: 7a1406
-    repository: https://github.com/apache/tomcat
-  - id: 9ac905
-    repository: https://github.com/apache/tomcat
-  - id: 0e8a50
-    repository: https://github.com/apache/tomcat
-  - id: 5a5494f
-    repository: https://github.com/apache/tomcat
   - id: 64159a
-    repository: https://github.com/apache/tomcat
-  - id: b99fba
     repository: https://github.com/apache/tomcat
   - id: 03c436
     repository: https://github.com/apache/tomcat
-  - id: 40d5d9
+- id: 9.0.x
+  commits:
+  - id: 64fa5b
     repository: https://github.com/apache/tomcat
-  - id: 9be576
+  - id: 7a1406
+    repository: https://github.com/apache/tomcat
+  - id: 0e8a50
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.41

--- a/statements/CVE-2020-1950/statement.yaml
+++ b/statements/CVE-2020-1950/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2020-1950
 notes:
 - text: A carefully crafted or corrupt PSD file can cause excessive memory usage in Apache Tika's PSDParser in versions 1.0-1.23.
 fixes:
-- id: DEFAULT_BRANCH
+- id: branch_1x
   commits:
   - id: 750d7790c7d8ba766f2794fac79521d5870eadf
     repository: https://github.com/apache/tika
+- id: DEFAULT_BRANCH
+  commits:
   - id: ab8a9ed830ec710a32e4ffdf4989aea3aaea92e
     repository: https://github.com/apache/tika
 artifacts:

--- a/statements/CVE-2020-1954/statement.yaml
+++ b/statements/CVE-2020-1954/statement.yaml
@@ -2,13 +2,17 @@ vulnerability_id: CVE-2020-1954
 notes:
 - text: Apache CXF has the ability to integrate with JMX by registering an InstrumentationManager extension with the CXF bus. If the ‘createMBServerConnectorFactory’ property of the default InstrumentationManagerImpl is not disabled, then it is vulnerable to a man-in-the-middle (MITM) style attack. An attacker on the same host can connect to the registry and rebind the entry to another server, thus acting as a proxy to the original. They are then able to gain access to all of the information that is sent and received over JMX.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 3.3.x-fixes
   commits:
   - id: 98ec361acd390483005de12ca3b10cf49cbdcf8
     repository: https://github.com/apache/cxf
+- id: DEFAULT_BRANCH
+  commits:
   - id: 1cf4fed546904a4a2560f53a2a2391d834b4026
     repository: https://github.com/apache/cxf
-  - id: 8636c3760a97979f42e45080230a27b81df5d43
+- id: DEFAULT_BRANCH
+  commits:
+  - id: 3.2.x-fixes
     repository: https://github.com/apache/cxf
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-rt-management@2.7.18

--- a/statements/CVE-2020-1954/statement.yaml
+++ b/statements/CVE-2020-1954/statement.yaml
@@ -10,9 +10,9 @@ fixes:
   commits:
   - id: 1cf4fed546904a4a2560f53a2a2391d834b4026
     repository: https://github.com/apache/cxf
-- id: DEFAULT_BRANCH
+- id: 3.2.x-fixes
   commits:
-  - id: 3.2.x-fixes
+  - id: 8636c3760a97979f42e45080230a27b81df5d43
     repository: https://github.com/apache/cxf
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-rt-management@2.7.18

--- a/statements/CVE-2020-1956/statement.yaml
+++ b/statements/CVE-2020-1956/statement.yaml
@@ -2,9 +2,11 @@ vulnerability_id: CVE-2020-1956
 notes:
 - text: Apache Kylin 2.3.0, and releases up to 2.6.5 and 3.0.1 has some restful apis which will concatenate os command with the user input string, a user is likely to be able to execute any os command without any protection or validation.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 3.0.x
   commits:
   - id: 58fad56ac6aaa43c6bd8f962d7f2d84438664092
     repository: https://github.com/apache/kylin
+- id: kylin3
+  commits:
   - id: 9cc3793ab2f2f0053c467a9b3f38cb7791cd436a
     repository: https://github.com/apache/kylin

--- a/statements/CVE-2020-1960/statement.yaml
+++ b/statements/CVE-2020-1960/statement.yaml
@@ -6,23 +6,43 @@ fixes:
   commits:
   - id: 48ca13793825a8095578ddc5724da4178cd18c5
     repository: https://github.com/apache/flink
+- id: release-1.7
+  commits:
   - id: 5e0b7970a9aea74aba4ebffaa75c37e960799b9
     repository: https://github.com/apache/flink
+- id: release-1.10
+  commits:
   - id: 804ae70024bf8be7c0c7093d02addb080c31866
     repository: https://github.com/apache/flink
+- id: release-1.1
+  commits:
   - id: a61b5d2b362d11e7b9deeb2334d275325574bd7
     repository: https://github.com/apache/flink
+- id: release-1.8
+  commits:
   - id: 0e8e8062bcc159e9ed2a0d4a0a61db4efcb01f2
     repository: https://github.com/apache/flink
+- id: release-1.4
+  commits:
   - id: 12787eceb49c566b28aa876fc2892d21a0ec3d7
     repository: https://github.com/apache/flink
+- id: release-1.3
+  commits:
   - id: 4f06bb75cd726096af43587ca4fb182b2e4bae2
     repository: https://github.com/apache/flink
+- id: release-1.9
+  commits:
   - id: 58b58f4b16a2e25c95b465377d43a51ad8ef3f6
     repository: https://github.com/apache/flink
+- id: release-1.6
+  commits:
   - id: b8647b1ca019003ae939b7494bba4e54de167b6
     repository: https://github.com/apache/flink
+- id: release-1.2
+  commits:
   - id: d2a051267ffbeef5c1fd981860fb7032d9ac8a6
     repository: https://github.com/apache/flink
+- id: release-1.5
+  commits:
   - id: f9b4e0dea71abbcd6463c757577c70c45b3e6bb
     repository: https://github.com/apache/flink

--- a/statements/CVE-2020-5408/statement.yaml
+++ b/statements/CVE-2020-5408/statement.yaml
@@ -6,10 +6,12 @@ fixes:
   commits:
   - id: c2296b0376d749aec43a1d68667d39116ccf3bf
     repository: https://github.com/spring-projects/spring-security
-- id: DEFAULT_BRANCH
+- id: 5.3.2
   commits:
   - id: d1909ec9c8844cfa6b63bab5c2591f14d714ef6
     repository: https://github.com/spring-projects/spring-security
+- id: 5.2.4
+  commits:
   - id: 564d5644c993f622db8bc22737471c57dd08d16
     repository: https://github.com/spring-projects/spring-security
 - id: 4.2.x

--- a/statements/CVE-2020-5408/statement.yaml
+++ b/statements/CVE-2020-5408/statement.yaml
@@ -2,16 +2,22 @@ vulnerability_id: CVE-2020-5408
 notes:
 - text: Spring Security versions 5.3.x prior to 5.3.2, 5.2.x prior to 5.2.4, 5.1.x prior to 5.1.10, 5.0.x prior to 5.0.16 and 4.2.x prior to 4.2.16 use a fixed null initialization vector with CBC Mode in the implementation of the queryable text encryptor. A malicious user with access to the data that has been encrypted using such an encryptor may be able to derive the unencrypted values using a dictionary attack.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 5.1.x
   commits:
   - id: c2296b0376d749aec43a1d68667d39116ccf3bf
     repository: https://github.com/spring-projects/spring-security
+- id: DEFAULT_BRANCH
+  commits:
   - id: d1909ec9c8844cfa6b63bab5c2591f14d714ef6
-    repository: https://github.com/spring-projects/spring-security
-  - id: 3c81e122bdfcd0803fb6331a8625624cae24923
     repository: https://github.com/spring-projects/spring-security
   - id: 564d5644c993f622db8bc22737471c57dd08d16
     repository: https://github.com/spring-projects/spring-security
+- id: 4.2.x
+  commits:
+  - id: 3c81e122bdfcd0803fb6331a8625624cae24923
+    repository: https://github.com/spring-projects/spring-security
+- id: 5.0.x
+  commits:
   - id: 62bc17ea3f2d5f052a7e9ce8e909255668034c0
     repository: https://github.com/spring-projects/spring-security
 artifacts:

--- a/statements/CVE-2020-5410/statement.yaml
+++ b/statements/CVE-2020-5410/statement.yaml
@@ -6,10 +6,12 @@ fixes:
   commits:
   - id: 03eaadc25323d8c8c89f528e8585033ed90c50f
     repository: https://github.com/spring-cloud/spring-cloud-config
-- id: DEFAULT_BRANCH
+- id: 3.0.0
   commits:
   - id: 2ec1acbed9505ab58d275ecd48e5f610d4b25da
     repository: https://github.com/spring-cloud/spring-cloud-config
+- id: 2.2.3
+  commits:
   - id: f470b52f1bb52bedac984c2101bea9a3ac52e2e
     repository: https://github.com/spring-cloud/spring-cloud-config
 artifacts:

--- a/statements/CVE-2020-5410/statement.yaml
+++ b/statements/CVE-2020-5410/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2020-5410
 notes:
 - text: Spring Cloud Config, versions 2.2.x prior to 2.2.3, versions 2.1.x prior to 2.1.9, and older unsupported versions allow applications to serve arbitrary configuration files through the spring-cloud-config-server module. A malicious user, or attacker, can send a request using a specially crafted URL that can lead to a directory traversal attack.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 2.1.x
   commits:
   - id: 03eaadc25323d8c8c89f528e8585033ed90c50f
     repository: https://github.com/spring-cloud/spring-cloud-config
+- id: DEFAULT_BRANCH
+  commits:
   - id: 2ec1acbed9505ab58d275ecd48e5f610d4b25da
     repository: https://github.com/spring-cloud/spring-cloud-config
   - id: f470b52f1bb52bedac984c2101bea9a3ac52e2e

--- a/statements/CVE-2020-5412/statement.yaml
+++ b/statements/CVE-2020-5412/statement.yaml
@@ -6,6 +6,8 @@ fixes:
   commits:
   - id: 624bbc8b50f7b5b6a1addc62040e4f2587f24f1
     repository: https://github.com/spring-cloud/spring-cloud-netflix
+- id: 2.1.x
+  commits:
   - id: a9f0315aad10fed83d98e5d143a82a5bf859c54
     repository: https://github.com/spring-cloud/spring-cloud-netflix
 artifacts:

--- a/statements/CVE-2020-7009/statement.yaml
+++ b/statements/CVE-2020-7009/statement.yaml
@@ -2,11 +2,15 @@ vulnerability_id: CVE-2020-7009
 notes:
 - text: Elasticsearch versions from 6.7.0 before 6.8.8 and 7.0.0 before 7.6.2 contain a privilege escalation flaw if an attacker is able to create API keys. An attacker who is able to generate an API key can perform a series of steps that result in an API key being generated with elevated privileges.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 6.8
   commits:
   - id: 1c5f53076b625c44111c1e9430dc36327a08858
     repository: https://github.com/elastic/elasticsearch
+- id: 7.6
+  commits:
   - id: 6f59ef267b2c3567754f8bea87daafc34cd9bd5
     repository: https://github.com/elastic/elasticsearch
+- id: 7.10
+  commits:
   - id: 7f21ade92407c5c65d2bd83a42e752838acdde5
     repository: https://github.com/elastic/elasticsearch

--- a/statements/CVE-2020-7019/statement.yaml
+++ b/statements/CVE-2020-7019/statement.yaml
@@ -6,7 +6,11 @@ fixes:
   commits:
   - id: 011773c8c2a662a011de659806bcf34596ba995
     repository: https://github.com/elastic/elasticsearch
+- id: 7.9
+  commits:
   - id: 37a38081ec1bf375ce6d480f147a1fdf04e9538
     repository: https://github.com/elastic/elasticsearch
+- id: 6.8
+  commits:
   - id: 8dbcd49dc71f0bb9b78b19a4cfb84af599b9c32
     repository: https://github.com/elastic/elasticsearch

--- a/statements/CVE-2020-7611/statement.yaml
+++ b/statements/CVE-2020-7611/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2020-7611
 notes:
 - text: All versions of io.micronaut:micronaut-http-client before 1.2.11 and all versions from 1.3.0 before 1.3.2 are vulnerable to HTTP Request Header Injection due to not validating request headers passed to the client.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 1.2.x
   commits:
   - id: 9d1eff5c8df1d6cda1fe00ef046729b2a6abe7f1
     repository: https://github.com/micronaut-projects/micronaut-core
+- id: 1.3.x
+  commits:
   - id: 6deb60b75517f80c57b42d935f07955c773b766d
     repository: https://github.com/micronaut-projects/micronaut-core
 artifacts:

--- a/statements/CVE-2020-9488/statement.yaml
+++ b/statements/CVE-2020-9488/statement.yaml
@@ -2,10 +2,12 @@ vulnerability_id: CVE-2020-9488
 notes:
 - text: Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender.
 fixes:
-- id: DEFAULT_BRANCH
+- id: 2.x
   commits:
   - id: 6851b5
     repository: https://github.com/apache/logging-log4j2
+- id: DEFAULT_BRANCH
+  commits:
   - id: fb91a3
     repository: https://github.com/apache/logging-log4j2
 artifacts:


### PR DESCRIPTION
36 CVEs have commits listed within the same fix id, which are actually on different branches and should thus be split into multiple separate fix IDs.
This applies for the following CVEs:
- CVE-2014-0225
- CVE-2014-1904
- CVE-2014-3625
- CVE-2015-5175
- CVE-2015-5348
- CVE-2017-12174
- CVE-2017-12612
- CVE-2017-7561
- CVE-2018-1271
- CVE-2018-11768
- CVE-2019-12399
- CVE-2019-12406
- CVE-2019-12419
- CVE-2019-12423
- CVE-2019-16869
- CVE-2019-17573
- CVE-2020-11002
- CVE-2020-11057
- CVE-2020-11969
- CVE-2020-11972
- CVE-2020-11975
- CVE-2020-11980
- CVE-2020-13920
- CVE-2020-1937
- CVE-2020-1938
- CVE-2020-1950
- CVE-2020-1954
- CVE-2020-1956
- CVE-2020-1960
- CVE-2020-5408
- CVE-2020-5410
- CVE-2020-5412
- CVE-2020-7009
- CVE-2020-7019
- CVE-2020-7611
- CVE-2020-9488