### PR TITLE
Expand truncated git commit ids and fix typos

### DIFF
--- a/statements/CVE-2008-6505/statement.yaml
+++ b/statements/CVE-2008-6505/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.1.x
   commits:
-  - id: 04fcefa44bae1263c7cad6986a9dafed67f0164
+  - id: 04fcefa44bae1263c7cad6986a9dafed67f0164f
     repository: https://github.com/apache/struts
 - id: 2.0.x
   commits:
-  - id: ff8b655c4b04cae41e5ad00df0a7482333e7a25
+  - id: ff8b655c4b04cae41e5ad00df0a7482333e7a254
     repository: https://github.com/apache/struts
 artifacts:
 - id: pkg:maven/org.apache.struts/struts2-core@2.0.5

--- a/statements/CVE-2008-6682/statement.yaml
+++ b/statements/CVE-2008-6682/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 2.1.1
   commits:
-  - id: 09147ffad2b3046ed21af0f524c5088e2ac551e
+  - id: 09147ffad2b3046ed21af0f524c5088e2ac551e6
     repository: https://github.com/apache/struts
-  - id: bd3f2f59c9b09f70aed3ebab6bb69b464ee2d6c
+  - id: bd3f2f59c9b09f70aed3ebab6bb69b464ee2d6cb
     repository: https://github.com/apache/struts
-  - id: dae026a0f0511f83852053bae9d5a622e7f8048
+  - id: dae026a0f0511f83852053bae9d5a622e7f80486
     repository: https://github.com/apache/struts
 - id: 2.0.x
   commits:
-  - id: dbc620f84ffb626c6e6738afe0578d617a2b3d3
+  - id: dbc620f84ffb626c6e6738afe0578d617a2b3d32
     repository: https://github.com/apache/struts
-  - id: 93866341ec5396d07b5829be55110ff09dc81bc
+  - id: 93866341ec5396d07b5829be55110ff09dc81bcd
     repository: https://github.com/apache/struts

--- a/statements/CVE-2013-2115/statement.yaml
+++ b/statements/CVE-2013-2115/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: STRUTS_2_3_14_2
   commits:
-  - id: d7804297e319c7a12245e1b536e565fcea6d650
+  - id: d7804297e319c7a12245e1b536e565fcea6d6503
     repository: https://github.com/apache/struts
-  - id: fed4f8e8a4ec69b5e7612b92d8ce3e476680474
+  - id: fed4f8e8a4ec69b5e7612b92d8ce3e476680474b
     repository: https://github.com/apache/struts
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2013-2134/statement.yaml
+++ b/statements/CVE-2013-2134/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: STRUTS_2_3_14_3
   commits:
-  - id: 01e6b251b4db78bfb7971033652e81d1af4cb3e
+  - id: 01e6b251b4db78bfb7971033652e81d1af4cb3e0
     repository: https://github.com/apache/struts
-  - id: 54e5c912ebd9a1599bfcf7a719da17c28127bbe
+  - id: 54e5c912ebd9a1599bfcf7a719da17c28127bbe3
     repository: https://github.com/apache/struts
-  - id: 8b4fc81daeea3834bcbf73de5f48d0021917aa3
+  - id: 8b4fc81daeea3834bcbf73de5f48d0021917aa37
     repository: https://github.com/apache/struts
-  - id: cfb6e9afbae320a4dd5bdd655154ab9fe5a92c1
+  - id: cfb6e9afbae320a4dd5bdd655154ab9fe5a92c16
     repository: https://github.com/apache/struts
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2013-2135/statement.yaml
+++ b/statements/CVE-2013-2135/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: STRUTS_2_3_14_3
   commits:
-  - id: cfb6e9afbae320a4dd5bdd655154ab9fe5a92c1
+  - id: cfb6e9afbae320a4dd5bdd655154ab9fe5a92c16
     repository: https://github.com/apache/struts
-  - id: 01e6b251b4db78bfb7971033652e81d1af4cb3e
+  - id: 01e6b251b4db78bfb7971033652e81d1af4cb3e0
     repository: https://github.com/apache/struts
-  - id: 54e5c912ebd9a1599bfcf7a719da17c28127bbe
+  - id: 54e5c912ebd9a1599bfcf7a719da17c28127bbe3
     repository: https://github.com/apache/struts
-  - id: 8b4fc81daeea3834bcbf73de5f48d0021917aa3
+  - id: 8b4fc81daeea3834bcbf73de5f48d0021917aa37
     repository: https://github.com/apache/struts
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2013-2248/statement.yaml
+++ b/statements/CVE-2013-2248/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: STRUTS_2_3_15_X
   commits:
-  - id: 3cfe34fefedcf0fdcfcb061c0aea34a715b7de6
+  - id: 3cfe34fefedcf0fdcfcb061c0aea34a715b7de63
     repository: https://github.com/apache/struts
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2013-2251/statement.yaml
+++ b/statements/CVE-2013-2251/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: STRUTS_2_3_15_X
   commits:
-  - id: 3cfe34fefedcf0fdcfcb061c0aea34a715b7de6
+  - id: 3cfe34fefedcf0fdcfcb061c0aea34a715b7de63
     repository: https://github.com/apache/struts
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2013-4002/statement.yaml
+++ b/statements/CVE-2013-4002/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: Xerces-J_2_12_0
   commits:
-  - id: 266e837852e0f0e3c8c1ad572b6fc4dbb4ded17
+  - id: 266e837852e0f0e3c8c1ad572b6fc4dbb4ded17b
     repository: https://github.com/apache/xerces2-j
 - id: Xerces-J_2_12_0-xml-schema-1.1
   commits:
-  - id: 628cbc7142ef9acfb61b8e571aab63504235849
+  - id: 628cbc7142ef9acfb61b8e571aab63504235849b
     repository: https://github.com/apache/xerces2-j
 artifacts:
 - id: pkg:maven/com.rackspace.apache/xerces2-xsd11@2.11.1

--- a/statements/CVE-2013-4221/statement.yaml
+++ b/statements/CVE-2013-4221/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: "2.4"
   commits:
-  - id: 12cc79b3953c7bd276e9f1cae2fbfdb9c1a6f07
+  - id: 12cc79b3953c7bd276e9f1cae2fbfdb9c1a6f070
     repository: https://github.com/restlet/restlet-framework-java
 - id: "2.1"
   commits:
-  - id: b85c2ef182c69c5e2e21df008ccb249ccf80c7b
+  - id: b85c2ef182c69c5e2e21df008ccb249ccf80c7b9
     repository: https://github.com/restlet/restlet-framework-java
 - id: "2.0"
   commits:
-  - id: c3015e4783c2a36e7528aa611c911b7d8c4ec5b
+  - id: c3015e4783c2a36e7528aa611c911b7d8c4ec5ba
     repository: https://github.com/restlet/restlet-framework-java

--- a/statements/CVE-2013-4330/statement.yaml
+++ b/statements/CVE-2013-4330/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: camel-2.12.x
   commits:
-  - id: 2281b1f365c50ee1a470fb9990b753eadee9095
+  - id: 2281b1f365c50ee1a470fb9990b753eadee90954
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: camel-2.9.x
   commits:
-  - id: 27a9752a565fbef436bac4fcf22d339e3295b2a
+  - id: 27a9752a565fbef436bac4fcf22d339e3295b2a0
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: camel-2.10.x
   commits:
-  - id: 3215fe50dd42c83a7a454dd36486843fe36eae4
+  - id: 3215fe50dd42c83a7a454dd36486843fe36eae48
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: DEFAULT_BRANCH
   commits:
@@ -20,7 +20,7 @@ fixes:
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: camel-2.11.x
   commits:
-  - id: ce19353f1297c5d3dc59be21a1ead89c0a44907
+  - id: ce19353f1297c5d3dc59be21a1ead89c0a44907a
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-file@3.2.0

--- a/statements/CVE-2013-4366/statement.yaml
+++ b/statements/CVE-2013-4366/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 08140864e3e4c0994e094c4cf0507932baf6a66
+  - id: 08140864e3e4c0994e094c4cf0507932baf6a66a
     repository: https://github.com/apache/httpcomponents-client
 artifacts:
 - id: pkg:maven/org.springframework.cloud/spring-cloud-contract-shade@1.1.4.RELEASE

--- a/statements/CVE-2013-6429/statement.yaml
+++ b/statements/CVE-2013-6429/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 4_x
   commits:
-  - id: 2ae6a6a3415eebc57babcb9d3e5505887eda6d8
+  - id: 2ae6a6a3415eebc57babcb9d3e5505887eda6d8a
     repository: https://github.com/spring-projects/spring-framework.git
 - id: 3_2_x
   commits:
-  - id: 7387cb990e35b0f1b573faf29d4f9ae183d7a5e
+  - id: 7387cb990e35b0f1b573faf29d4f9ae183d7a5ef
     repository: https://github.com/spring-projects/spring-framework.git
 artifacts:
 - id: pkg:maven/org.springframework/spring-web@4.3.0.RELEASE

--- a/statements/CVE-2013-7398/statement.yaml
+++ b/statements/CVE-2013-7398/statement.yaml
@@ -8,7 +8,7 @@ fixes:
     repository: https://github.com/AsyncHttpClient/async-http-client
 - id: 1.9.x
   commits:
-  - id: a894583921c11c3b01f160ada36a8bb9d5158e9
+  - id: a894583921c11c3b01f160ada36a8bb9d5158e96
     repository: https://github.com/AsyncHttpClient/async-http-client
 artifacts:
 - id: pkg:maven/org.glassfish.grizzly/grizzly-http-client@1.11

--- a/statements/CVE-2014-0002/statement.yaml
+++ b/statements/CVE-2014-0002/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: camel-2.12.x
   commits:
-  - id: 54b65c1d30848835f26bd138c0ba407bc1e560d
+  - id: 54b65c1d30848835f26bd138c0ba407bc1e560da
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: camel-2.11.x
   commits:
-  - id: 2ec54fa0c13ae65bdcccff764af081a79fcc05f
+  - id: 2ec54fa0c13ae65bdcccff764af081a79fcc05f9
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2014-0003/statement.yaml
+++ b/statements/CVE-2014-0003/statement.yaml
@@ -8,11 +8,11 @@ fixes:
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: camel-2.12.x
   commits:
-  - id: 483b445dc77487e2d0f3d8c8bf1a7bbab04464c
+  - id: 483b445dc77487e2d0f3d8c8bf1a7bbab04464c9
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 - id: camel-2.11.x
   commits:
-  - id: c6de749e9b3c7b61861c5480e91550290585224
+  - id: c6de749e9b3c7b61861c5480e91550290585224d
     repository: https://git-wip-us.apache.org/repos/asf/camel.git
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-xml-jaxp@3.2.0

--- a/statements/CVE-2014-1858/statement.yaml
+++ b/statements/CVE-2014-1858/statement.yaml
@@ -9,7 +9,7 @@ fixes:
     repository: https://github.com/numpy/numpy
 - id: 1.8.x
   commits:
-  - id: 961c43da78bf97ce63183b27c338db7ea77bed8
+  - id: 961c43da78bf97ce63183b27c338db7ea77bed85
     repository: https://github.com/numpy/numpy
 artifacts:
 - id: pkg:maven/numpy/numpy@1.14.1

--- a/statements/CVE-2014-3527/statement.yaml
+++ b/statements/CVE-2014-3527/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: "3_2"
   commits:
-  - id: 2cb99f079152ac05cee5c90457c7feb3bb2de55
+  - id: 2cb99f079152ac05cee5c90457c7feb3bb2de55e
     repository: https://github.com/spring-projects/spring-security.git
 - id: "3_1"
   commits:
-  - id: 934937d9c1dc20c396b96c08310b72cfa627acb
+  - id: 934937d9c1dc20c396b96c08310b72cfa627acbf
     repository: https://github.com/spring-projects/spring-security.git
 artifacts:
 - id: pkg:maven/org.springframework.security/spring-security-cas@5.3.2.RELEASE

--- a/statements/CVE-2014-3682/statement.yaml
+++ b/statements/CVE-2014-3682/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 6.0.x
   commits:
-  - id: 5641588c730cc75dc3b76c34b76271fbd407fb8
+  - id: 5641588c730cc75dc3b76c34b76271fbd407fb84
     repository: https://github.com/kiegroup/jbpm-designer
-  - id: be3968d51299f6de0011324be60223ede49ecb1
+  - id: be3968d51299f6de0011324be60223ede49ecb1c
     repository: https://github.com/kiegroup/jbpm-designer
 - id: 6.2.x
   commits:
-  - id: 69d8f6b7a099594bd0536f88d52875387585708
+  - id: 69d8f6b7a099594bd0536f88d528753875857088
     repository: https://github.com/kiegroup/jbpm-designer
-  - id: e4691214a100718c3b1c9b93d4db466672ba0be
+  - id: e4691214a100718c3b1c9b93d4db466672ba0be3
     repository: https://github.com/kiegroup/jbpm-designer

--- a/statements/CVE-2014-6633/statement.yaml
+++ b/statements/CVE-2014-6633/statement.yaml
@@ -12,25 +12,25 @@ fixes:
     repository: https://github.com/tryton/trytond
 - id: "2.8"
   commits:
-  - id: 37cd017ce2aaa346582fb53fd418c27449e0029
+  - id: 37cd017ce2aaa346582fb53fd418c27449e00295
     repository: https://github.com/tryton/trytond
-  - id: 5781ddbc5a4383a937f9d1c56344b81933f8697
+  - id: 5781ddbc5a4383a937f9d1c56344b81933f86977
     repository: https://github.com/tryton/trytond
 - id: "3.2"
   commits:
-  - id: 56a8b67b94ce0d5426af5ec7e5665f9c74afb73
+  - id: 56a8b67b94ce0d5426af5ec7e5665f9c74afb732
     repository: https://github.com/tryton/trytond
-  - id: 92838f6da258ad9f7344c5eb1d10951decc115a
+  - id: 92838f6da258ad9f7344c5eb1d10951decc115a5
     repository: https://github.com/tryton/trytond
 - id: "2.4"
   commits:
-  - id: 6e7fc491128bfb81f6441c018361c83787a6500
+  - id: 6e7fc491128bfb81f6441c018361c83787a65002
     repository: https://github.com/tryton/trytond
-  - id: dd0dc77c928e012497cf7a231858b5794a7b0b4
+  - id: dd0dc77c928e012497cf7a231858b5794a7b0b49
     repository: https://github.com/tryton/trytond
 - id: "2.6"
   commits:
-  - id: 755fec183cf17816c0ded2b8e5cda89e527744b
+  - id: 755fec183cf17816c0ded2b8e5cda89e527744b6
     repository: https://github.com/tryton/trytond
-  - id: dc0c3cd5176819efdbf0d22376c8ad2f298e14a
+  - id: dc0c3cd5176819efdbf0d22376c8ad2f298e14a5
     repository: https://github.com/tryton/trytond

--- a/statements/CVE-2015-1326/statement.yaml
+++ b/statements/CVE-2015-1326/statement.yaml
@@ -6,5 +6,5 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 4e7d0df9093
+  - id: 4e7d0df909338eb3c44b083722c7bf8b76bdf940
     repository: https://github.com/martinpitt/python-dbusmock

--- a/statements/CVE-2015-2156/statement.yaml
+++ b/statements/CVE-2015-2156/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: "4.1"
   commits:
-  - id: 97d871a7553a01384b43df855dccdda5205ae77
+  - id: 97d871a7553a01384b43df855dccdda5205ae77a
     repository: https://github.com/netty/netty
 - id: "3.10"
   commits:
-  - id: 2caa38a2795fe1f1ae6ceda4d69e826ed7c55e5
+  - id: 2caa38a2795fe1f1ae6ceda4d69e826ed7c55e55
     repository: https://github.com/netty/netty
 - id: "3.9"
   commits:
-  - id: 31815598a2af37f0b71ea94eada70d6659c2375
+  - id: 31815598a2af37f0b71ea94eada70d6659c23752
     repository: https://github.com/netty/netty
 artifacts:
 - id: pkg:maven/io.netty/netty-all@4.0.23.Final

--- a/statements/CVE-2015-3192/statement.yaml
+++ b/statements/CVE-2015-3192/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: 3.2.x
   commits:
-  - id: 5a711c05ec750f069235597173084c2ee796242
+  - id: 5a711c05ec750f069235597173084c2ee7962424
     repository: https://github.com/spring-projects/spring-framework.git
 artifacts:
 - id: pkg:maven/org.springframework/spring-web@4.3.0.RELEASE

--- a/statements/CVE-2015-5254/statement.yaml
+++ b/statements/CVE-2015-5254/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: activemq-5.11.x
   commits:
-  - id: 6f03921b31d9fefeddb0f4fa63150ed1f94a14b
+  - id: 6f03921b31d9fefeddb0f4fa63150ed1f94a14b1
     repository: https://github.com/apache/activemq
-  - id: 73a0caf758f9e4916783a205c7e422b4db27905
+  - id: 73a0caf758f9e4916783a205c7e422b4db27905c
     repository: https://github.com/apache/activemq
 - id: activemq-5.12.x
   commits:
-  - id: 7eb9b218b2705cf9273e30ee2da026e43b6dd4e
+  - id: 7eb9b218b2705cf9273e30ee2da026e43b6dd4e0
     repository: https://github.com/apache/activemq
-  - id: e7a4b53f799685e337972dd36ba0253c04bcc01
+  - id: e7a4b53f799685e337972dd36ba0253c04bcc01f
     repository: https://github.com/apache/activemq
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2015-7559/statement.yaml
+++ b/statements/CVE-2015-7559/statement.yaml
@@ -8,7 +8,7 @@ fixes:
     repository: https://git-wip-us.apache.org/repos/asf/activemq.git
 - id: 5.14.x
   commits:
-  - id: b8fc78ec6c367cbe2a40a674eaec64ac3d7d1ec
+  - id: b8fc78ec6c367cbe2a40a674eaec64ac3d7d1ecb
     repository: https://git-wip-us.apache.org/repos/asf/activemq.git
 artifacts:
 - id: pkg:maven/org.apache.activemq/activemq-client@5.14.5

--- a/statements/CVE-2016-10726/statement.yaml
+++ b/statements/CVE-2016-10726/statement.yaml
@@ -4,17 +4,17 @@ notes:
 fixes:
 - id: "3.6"
   commits:
-  - id: 00fd623c23635688f361fa02e526aca5ff5e223
+  - id: 00fd623c23635688f361fa02e526aca5ff5e2233
     repository: https://github.com/DSpace/DSpace
 - id: master
   commits:
-  - id: 48826b5164466387f5364b1f180ad4b4b632e23
+  - id: 48826b5164466387f5364b1f180ad4b4b632e23c
     repository: https://github.com/DSpace/DSpace
 - id: "5.5"
   commits:
-  - id: 98a26fa3e7d6ca852d8ee73c0edf9c77396db1c
+  - id: 98a26fa3e7d6ca852d8ee73c0edf9c77396db1ca
     repository: https://github.com/DSpace/DSpace
 - id: "4.5"
   commits:
-  - id: be17e8b9f6eeda2e915a8cdfa57ff019ee53c79
+  - id: be17e8b9f6eeda2e915a8cdfa57ff019ee53c790
     repository: https://github.com/DSpace/DSpace

--- a/statements/CVE-2016-2141/statement.yaml
+++ b/statements/CVE-2016-2141/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 38a882331035ffed205d15a5c92b471fd09659c
+  - id: 38a882331035ffed205d15a5c92b471fd09659c0
     repository: https://github.com/belaban/JGroups
 - id: 3.6.10
   commits:
-  - id: fba182c14075789e1d2c976d50d9018c671ad0b
+  - id: fba182c14075789e1d2c976d50d9018c671ad0b4
     repository: https://github.com/belaban/JGroups
 artifacts:
 - id: pkg:maven/org.jgroups/com.springsource.org.jgroups@2.2.8

--- a/statements/CVE-2016-2174/statement.yaml
+++ b/statements/CVE-2016-2174/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: "0.5"
   commits:
-  - id: 8618870d1b4acfae4114dd247a362cfa8493ab9
+  - id: 8618870d1b4acfae4114dd247a362cfa8493ab9e
     repository: https://github.com/apache/ranger
 - id: master
   commits:
-  - id: da3a3233d5679284142eb2887c91a754a0da70b
+  - id: da3a3233d5679284142eb2887c91a754a0da70b9
     repository: https://github.com/apache/ranger

--- a/statements/CVE-2016-2402/statement.yaml
+++ b/statements/CVE-2016-2402/statement.yaml
@@ -10,7 +10,7 @@ fixes:
     repository: https://github.com/square/okhttp
 - id: 2.x
   commits:
-  - id: 5377f25d9eed755328216912ef5e922c93e14f3
+  - id: 5377f25d9eed755328216912ef5e922c93e14f3e
     repository: https://github.com/square/okhttp
 artifacts:
 - id: pkg:maven/com.squareup.okhttp/okhttp@2.2.0

--- a/statements/CVE-2016-3087/statement.yaml
+++ b/statements/CVE-2016-3087/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2_5_x
   commits:
-  - id: 6bd694b7980494c12d49ca1bf39f12aec3e03e2f:2_5_x
+  - id: 6bd694b7980494c12d49ca1bf39f12aec3e03e2f
     repository: https://github.com/apache/struts.git
 - id: 2_3_x
   commits:
-  - id: 98d2692e434fe7f4d445ade24fe2c9860de1c13f:2_3_x
+  - id: 98d2692e434fe7f4d445ade24fe2c9860de1c13f
     repository: https://github.com/apache/struts.git
 artifacts:
 - id: pkg:maven/org.apache.struts/struts2-core@2.3.15

--- a/statements/CVE-2016-3674/statement.yaml
+++ b/statements/CVE-2016-3674/statement.yaml
@@ -14,13 +14,13 @@ fixes:
     repository: https://github.com/x-stream/xstream
 - id: v-1.4.x
   commits:
-  - id: 5b5cd6d8137f645c5d57b648afb1a305967aa7f
+  - id: 5b5cd6d8137f645c5d57b648afb1a305967aa7f4
     repository: https://github.com/x-stream/xstream
-  - id: 696ec886a23dae880cf12e34e1fe09c5df8fe94
+  - id: 696ec886a23dae880cf12e34e1fe09c5df8fe946
     repository: https://github.com/x-stream/xstream
-  - id: 806949e1b3c22a3b31819a37402489a0303221a
+  - id: 806949e1b3c22a3b31819a37402489a0303221a1
     repository: https://github.com/x-stream/xstream
-  - id: e4f1457e681e015be83c6b0b84947676980e29d
+  - id: e4f1457e681e015be83c6b0b84947676980e29d3
     repository: https://github.com/x-stream/xstream
 artifacts:
 - id: pkg:maven/org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream@1.4.3_1

--- a/statements/CVE-2016-4970/statement.yaml
+++ b/statements/CVE-2016-4970/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: "4.0"
   commits:
-  - id: 524156f164a910b8b0978d27a2c700a19cd8048
+  - id: 524156f164a910b8b0978d27a2c700a19cd8048f
     repository: https://github.com/netty/netty
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2016-5001/statement.yaml
+++ b/statements/CVE-2016-5001/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.6.4
   commits:
-  - id: 04b8a19f81ee616c315eec639642439b3a18ad9
+  - id: 04b8a19f81ee616c315eec639642439b3a18ad9c
     repository: https://github.com/apache/hadoop
 - id: 2.7.2
   commits:
-  - id: 82ec5dbb2505066da8a6ed008d943b5ada027b1
+  - id: 82ec5dbb2505066da8a6ed008d943b5ada027b15
     repository: https://github.com/apache/hadoop
 artifacts:
 - id: pkg:maven/org.apache.hadoop/hadoop-hdfs-client@3.2.0

--- a/statements/CVE-2016-5016/statement.yaml
+++ b/statements/CVE-2016-5016/statement.yaml
@@ -8,11 +8,11 @@ fixes:
     repository: https://github.com/cloudfoundry/uaa
 - id: 2.7.4.x
   commits:
-  - id: 90b6f8c06afd96efd39f87deaaf9a94cd0fd082
+  - id: 90b6f8c06afd96efd39f87deaaf9a94cd0fd082e
     repository: https://github.com/cloudfoundry/uaa
 - id: 3.3.0.x
   commits:
-  - id: bc91ccd2029e8f1cea0c647f0c9aad4585f7a2c
+  - id: bc91ccd2029e8f1cea0c647f0c9aad4585f7a2c8
     repository: https://github.com/cloudfoundry/uaa
 artifacts:
 - id: pkg:maven/org.cloudfoundry.identity/cloudfoundry-identity-common@2.2.6

--- a/statements/CVE-2016-6793/statement.yaml
+++ b/statements/CVE-2016-6793/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: 1_5_x
   commits:
-  - id: 134686ef7185d3f96fec953136ab4847cd36b68
+  - id: 134686ef7185d3f96fec953136ab4847cd36b68d
     repository: https://github.com/apache/wicket.git
 artifacts:
 - id: pkg:maven/org.apache.wicket/wicket@1.4.20

--- a/statements/CVE-2016-8749/statement.yaml
+++ b/statements/CVE-2016-8749/statement.yaml
@@ -4,33 +4,33 @@ notes:
 fixes:
 - id: camel-2.19
   commits:
-  - id: 02270ab9c90ac0d59b85dbd59fb9c1007eb44a1
+  - id: 02270ab9c90ac0d59b85dbd59fb9c1007eb44a1b
     repository: https://github.com/apache/camel.git
-  - id: 2b0e96117d6f01eba0c18e2ff8df6a438e81972
+  - id: 2b0e96117d6f01eba0c18e2ff8df6a438e819721
     repository: https://github.com/apache/camel.git
-  - id: 7567488f844f01d72840f7ab6ca18114a11f20d
+  - id: 7567488f844f01d72840f7ab6ca18114a11f20d8
     repository: https://github.com/apache/camel.git
-  - id: 881e5099f94316d4a66ffbff0a3e6915829d49d
+  - id: 881e5099f94316d4a66ffbff0a3e6915829d49d7
     repository: https://github.com/apache/camel.git
-  - id: af3f54de35a90a5a49a4af4622e8bd1011bf5ec
+  - id: af3f54de35a90a5a49a4af4622e8bd1011bf5ecc
     repository: https://github.com/apache/camel.git
 - id: camel-2.17.x
   commits:
-  - id: 5ae9c0dcc4843347cd01ffb58ce5dd0687755a1
+  - id: 5ae9c0dcc4843347cd01ffb58ce5dd0687755a14
     repository: https://github.com/apache/camel.git
-  - id: c93a87c36aa4d14ad6f7ee1df9507fa2ca1fd91
+  - id: c93a87c36aa4d14ad6f7ee1df9507fa2ca1fd91a
     repository: https://github.com/apache/camel.git
-  - id: d4102512147eca2af21c3b6ed63a67d852f4e66
+  - id: d4102512147eca2af21c3b6ed63a67d852f4e66a
     repository: https://github.com/apache/camel.git
-  - id: 10f552643d7e4565104d142bbc160db5a30f9f7
+  - id: 10f552643d7e4565104d142bbc160db5a30f9f7e
     repository: https://github.com/apache/camel.git
 - id: camel-2.16.x
   commits:
-  - id: 235036d2396ae45b6809b72a1983dee33b5ba32
+  - id: 235036d2396ae45b6809b72a1983dee33b5ba326
     repository: https://github.com/apache/camel.git
-  - id: 57d01e2fc8923263df896e9810329ee5b7f9b69
+  - id: 57d01e2fc8923263df896e9810329ee5b7f9b69e
     repository: https://github.com/apache/camel.git
-  - id: ccf149c76bf37adc5977dc626e141a14e60b5ae
+  - id: ccf149c76bf37adc5977dc626e141a14e60b5aee
     repository: https://github.com/apache/camel.git
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-core@2.19.1

--- a/statements/CVE-2017-12174/statement.yaml
+++ b/statements/CVE-2017-12174/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 1.5.6
   commits:
-  - id: 0f081e96a504a87a674a873e91e49e7a258216e
+  - id: 0f081e96a504a87a674a873e91e49e7a258216e9
     repository: https://github.com/apache/activemq-artemis
 - id: DEFAULT_BRANCH
   commits:
-  - id: 76b1f9cf8faa4797122ac71273b507bf146e1c0
+  - id: 76b1f9cf8faa4797122ac71273b507bf146e1c06
     repository: https://github.com/apache/activemq-artemis
 artifacts:
 - id: pkg:maven/org.apache.activemq/artemis-commons@1.5.1

--- a/statements/CVE-2017-12610/statement.yaml
+++ b/statements/CVE-2017-12610/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 0.10.2
   commits:
-  - id: 0b4daa4bf48517b4b3e9cda11692e80ade620b0
+  - id: 0b4daa4bf48517b4b3e9cda11692e80ade620b04
     repository: https://github.com/apache/kafka
 - id: master
   commits:
-  - id: 47c2753496875db2849065ad91ee03c7c842c8e
+  - id: 47c2753496875db2849065ad91ee03c7c842c8e9
     repository: https://github.com/apache/kafka
 - id: 0.11.0
   commits:
-  - id: 9f3468645b968761ca9141d18337cb6adadbae9
+  - id: 9f3468645b968761ca9141d18337cb6adadbae97
     repository: https://github.com/apache/kafka
 artifacts:
 - id: pkg:maven/org.apache.kafka/kafka-clients@0.11.0.3

--- a/statements/CVE-2017-12611/statement.yaml
+++ b/statements/CVE-2017-12611/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
   - id: support-2-3
     commits:
-      - id: 2306f5f7fad7f0157f216f34331238feb0539fa
+      - id: 2306f5f7fad7f0157f216f34331238feb0539fa6
         repository: https://gitbox.apache.org/repos/asf/struts.git
   - id: master
     commits:
-      - id: 637ad1c3707266c33daabb18d7754e795e6681f
+      - id: 637ad1c3707266c33daabb18d7754e795e6681f3
         repository: https://gitbox.apache.org/repos/asf/struts.git
 artifacts:
   - id: pkg:maven/org.apache.struts/struts2-core@2.0.5

--- a/statements/CVE-2017-12612/statement.yaml
+++ b/statements/CVE-2017-12612/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 2.0.x
   commits:
-  - id: f7cbf90a72a19476ea2d3d1ddc96c45a24b9f57
+  - id: f7cbf90a72a19476ea2d3d1ddc96c45a24b9f57d
     repository: https://github.com/apache/spark
 - id: 2.1.x
   commits:
-  - id: 0b25a7d93359e348e11b2e8698990a53436b3c5
+  - id: 0b25a7d93359e348e11b2e8698990a53436b3c5d
     repository: https://github.com/apache/spark
 - id: 2.2.x
   commits:
-  - id: 4cba3b5a350f4d477466fc73b32cbd653eee840
+  - id: 4cba3b5a350f4d477466fc73b32cbd653eee8405
     repository: https://github.com/apache/spark
 - id: branch-2.1
   commits:
@@ -24,7 +24,7 @@ fixes:
     repository: https://github.com/apache/spark
 - id: 2.3.x
   commits:
-  - id: 8efc6e986554ae66eab93cd64a9035d716adbab
+  - id: 8efc6e986554ae66eab93cd64a9035d716adbab0
     repository: https://github.com/apache/spark
 artifacts:
 - id: pkg:maven/org.apache.spark/spark-launcher_2.11@2.4.5

--- a/statements/CVE-2017-12624/statement.yaml
+++ b/statements/CVE-2017-12624/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: 3.1.x-fixes
   commits:
-  - id: 896bd961cbbb6b8569700e5b70229f78f94ad9d
+  - id: 896bd961cbbb6b8569700e5b70229f78f94ad9dd
     repository: https://github.com/apache/cxf
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2017-12629/statement.yaml
+++ b/statements/CVE-2017-12629/statement.yaml
@@ -4,23 +4,23 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 926cc4d65b6d2cc40ff07f76d50ddeda947e3cc
+  - id: 926cc4d65b6d2cc40ff07f76d50ddeda947e3cc4
     repository: https://github.com/apache/lucene-solr
 - id: "7.2"
   commits:
-  - id: d28baa3fc5566b47f1ca7cc2ba1aba658dc634a
+  - id: d28baa3fc5566b47f1ca7cc2ba1aba658dc634ae
     repository: https://github.com/apache/lucene-solr
 - id: 5.5.5
   commits:
-  - id: d8000beebfb13ba0b6e754f84c760e11592d8d1
+  - id: d8000beebfb13ba0b6e754f84c760e11592d8d14
     repository: https://github.com/apache/lucene-solr
 - id: 6.6.2
   commits:
-  - id: f9fd6e9e26224f26f1542224ce187e04c27b268
+  - id: f9fd6e9e26224f26f1542224ce187e04c27b2681
     repository: https://github.com/apache/lucene-solr
 - id: "7.1"
   commits:
-  - id: 3bba91131b5257e64b9d0a2193e1e32a145b2a2
+  - id: 3bba91131b5257e64b9d0a2193e1e32a145b2a23
     repository: https://github.com/apache/lucene-solr
 artifacts:
 - id: pkg:maven/org.apache.lucene/lucene-queryparser@7.1.0

--- a/statements/CVE-2017-12631/statement.yaml
+++ b/statements/CVE-2017-12631/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: 1.4.x-fixes
   commits:
-  - id: ccdb12b26ff89e0a998a333e84dd84bd713ac76
+  - id: ccdb12b26ff89e0a998a333e84dd84bd713ac76c
     repository: https://github.com/apache/cxf-fediz
 - id: DEFAULT_BRANCH
   commits:
@@ -12,5 +12,5 @@ fixes:
     repository: https://github.com/apache/cxf-fediz
 - id: 1.3.x-fixes
   commits:
-  - id: 48dd9b68d67c6b729376c1ce8886f52a57df6c4
+  - id: 48dd9b68d67c6b729376c1ce8886f52a57df6c45
     repository: https://github.com/apache/cxf-fediz

--- a/statements/CVE-2017-12852/statement.yaml
+++ b/statements/CVE-2017-12852/statement.yaml
@@ -11,9 +11,9 @@ fixes:
     repository: https://github.com/numpy/numpy
 - id: 1.13.x
   commits:
-  - id: ba443cedf6e0194ab85f362f7d7ca89dca432e7
+  - id: ba443cedf6e0194ab85f362f7d7ca89dca432e77
     repository: https://github.com/numpy/numpy
-  - id: d57ada7c0c9900bfe8dfa139fa6419c4307ecb2
+  - id: d57ada7c0c9900bfe8dfa139fa6419c4307ecb25
     repository: https://github.com/numpy/numpy
 artifacts:
 - id: pkg:maven/numpy/numpy@1.14.1

--- a/statements/CVE-2017-14949/statement.yaml
+++ b/statements/CVE-2017-14949/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: "2.4"
   commits:
-  - id: 97a8d1d62612683817c785e99c4166bcde8cf1c
+  - id: 97a8d1d62612683817c785e99c4166bcde8cf1c7
     repository: https://github.com/restlet/restlet-framework-java
 - id: "2.3"
   commits:
-  - id: fe75aff3af23b879b984db7a2b6824cee0ef0fc
+  - id: fe75aff3af23b879b984db7a2b6824cee0ef0fc5
     repository: https://github.com/restlet/restlet-framework-java

--- a/statements/CVE-2017-15709/statement.yaml
+++ b/statements/CVE-2017-15709/statement.yaml
@@ -8,11 +8,11 @@ fixes:
     repository: https://github.com/apache/activemq
 - id: 5.14.x
   commits:
-  - id: 8ff18c5e254bf43395f2e0d7e3a1092b33ec646
+  - id: 8ff18c5e254bf43395f2e0d7e3a1092b33ec6462
     repository: https://github.com/apache/activemq
 - id: 5.15.x
   commits:
-  - id: d2e49be3a8f21d862726c1f6bc9e1caa6ee8b58
+  - id: d2e49be3a8f21d862726c1f6bc9e1caa6ee8b581
     repository: https://github.com/apache/activemq
 artifacts:
 - id: pkg:maven/org.apache.activemq/activemq-client@5.14.5

--- a/statements/CVE-2017-15719/statement.yaml
+++ b/statements/CVE-2017-15719/statement.yaml
@@ -4,25 +4,25 @@ notes:
 fixes:
 - id: 6.28.1
   commits:
-  - id: 3e8cfdcb0f8e6e0cf0da01e74501afb5c9bff0f
+  - id: 3e8cfdcb0f8e6e0cf0da01e74501afb5c9bff0f9
     repository: https://github.com/sebfz1/wicket-jquery-ui
-  - id: 6f33727a1b4aa27d58d672a96154d9061db43fa
+  - id: 6f33727a1b4aa27d58d672a96154d9061db43fa0
     repository: https://github.com/sebfz1/wicket-jquery-ui
-  - id: fa0ce80f8e92c28c801773ed7c28621ae98e872
+  - id: fa0ce80f8e92c28c801773ed7c28621ae98e872c
     repository: https://github.com/sebfz1/wicket-jquery-ui
 - id: 8.0.0-M8.1
   commits:
-  - id: 42294cc890536459b13cf16844cd65cccf66578
+  - id: 42294cc890536459b13cf16844cd65cccf665787
     repository: https://github.com/sebfz1/wicket-jquery-ui
-  - id: 82d81bf704bef90b42f62aecbcc7e8c460814b6
+  - id: 82d81bf704bef90b42f62aecbcc7e8c460814b67
     repository: https://github.com/sebfz1/wicket-jquery-ui
-  - id: 936c12a2db262cf471c781f0d3c0d0ad61c35c7
+  - id: 936c12a2db262cf471c781f0d3c0d0ad61c35c7b
     repository: https://github.com/sebfz1/wicket-jquery-ui
 - id: 7.9.2
   commits:
-  - id: 8aebe1e49a71f10cdd6a073fd09d0d8d82352a0
+  - id: 8aebe1e49a71f10cdd6a073fd09d0d8d82352a01
     repository: https://github.com/sebfz1/wicket-jquery-ui
-  - id: 9f082950a276c8948a4078c2438e284a948ba15
+  - id: 9f082950a276c8948a4078c2438e284a948ba153
     repository: https://github.com/sebfz1/wicket-jquery-ui
-  - id: cc75fdc3e610985a5f391789d33fb70c8c9114d
+  - id: cc75fdc3e610985a5f391789d33fb70c8c9114d6
     repository: https://github.com/sebfz1/wicket-jquery-ui

--- a/statements/CVE-2017-3154/statement.yaml
+++ b/statements/CVE-2017-3154/statement.yaml
@@ -4,5 +4,5 @@ notes:
 fixes:
 - id: 0.7-incubating
   commits:
-  - id: 0dcfd21bbfaac6f037f46b7aaaab0e5546fd2a7
+  - id: 0dcfd21bbfaac6f037f46b7aaaab0e5546fd2a78
     repository: https://github.com/apache/atlas

--- a/statements/CVE-2017-3156/statement.yaml
+++ b/statements/CVE-2017-3156/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 3.0.x
   commits:
-  - id: "1338469"
+  - id: "1338469f7d25cfcda75b547c68bed95bd97903ac"
     repository: https://github.com/apache/cxf.git
 - id: 3.1.x
   commits:
-  - id: 555843f
+  - id: 555843f9563ccfc2ca1afb2950aebb4505d7711b
     repository: https://github.com/apache/cxf.git
 - id: DEFAULT_BRANCH
   commits:
-  - id: e66ce235
+  - id: e66ce235ee5f8dbde467c8c23eeb622b072d0bf3
     repository: https://github.com/apache/cxf.git
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-rt-rs-security-oauth2@3.1.17

--- a/statements/CVE-2017-3163/statement.yaml
+++ b/statements/CVE-2017-3163/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: branch_6_4
   commits:
-  - id: 3a4f885b18bc963a8326c752bd229497908f1db
+  - id: 3a4f885b18bc963a8326c752bd229497908f1dbc
     repository: https://git-wip-us.apache.org/repos/asf/lucene-solr
 - id: DEFAULT_BRANCH
   commits:
@@ -12,11 +12,11 @@ fixes:
     repository: https://git-wip-us.apache.org/repos/asf/lucene-solr
 - id: branch_6x
   commits:
-  - id: 7088137d52256354a52ed86547b9faa0e704293
+  - id: 7088137d52256354a52ed86547b9faa0e7042934
     repository: https://git-wip-us.apache.org/repos/asf/lucene-solr
 - id: branch_5_5
   commits:
-  - id: ae789c252687dc8a18bfdb677f2e6cd14570e4d
+  - id: ae789c252687dc8a18bfdb677f2e6cd14570e4db
     repository: https://git-wip-us.apache.org/repos/asf/lucene-solr
 artifacts:
 - id: pkg:maven/org.apache.solr/solr-core@7.1.0

--- a/statements/CVE-2017-3164/statement.yaml
+++ b/statements/CVE-2017-3164/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 8b54b20fc488ae3e83f4a350a707dc0303ade23
+  - id: 8b54b20fc488ae3e83f4a350a707dc0303ade230
     repository: https://github.com/apache/lucene-solr
 - id: 8.x
   commits:
-  - id: e9db95831b9db69fbc0bef499b0d3f41bc6448f
+  - id: e9db95831b9db69fbc0bef499b0d3f41bc6448f1
     repository: https://github.com/apache/lucene-solr
 - id: 7.x
   commits:
-  - id: 6d63958821232699f0a8423d9b21d4915bfba64
+  - id: 6d63958821232699f0a8423d9b21d4915bfba64e
     repository: https://github.com/apache/lucene-solr
 artifacts:
 - id: pkg:maven/org.apache.solr/solr-core@7.1.0

--- a/statements/CVE-2017-4960/statement.yaml
+++ b/statements/CVE-2017-4960/statement.yaml
@@ -8,7 +8,7 @@ fixes:
     repository: https://github.com/cloudfoundry/uaa
 - id: 3.9.8
   commits:
-  - id: 78731f8aa37a53385d0194821a5356ab66e2138
+  - id: 78731f8aa37a53385d0194821a5356ab66e21385
     repository: https://github.com/cloudfoundry/uaa
 artifacts:
 - id: pkg:maven/org.cloudfoundry.identity/cloudfoundry-identity-server@3.7.3

--- a/statements/CVE-2017-4971/statement.yaml
+++ b/statements/CVE-2017-4971/statement.yaml
@@ -8,7 +8,7 @@ fixes:
     repository: https://github.com/spring-projects/spring-webflow
 - id: 2.5.x
   commits:
-  - id: ec3d54d2305e6b6bce12f770fec67fe63008d45
+  - id: ec3d54d2305e6b6bce12f770fec67fe63008d45b
     repository: https://github.com/spring-projects/spring-webflow
 artifacts:
 - id: pkg:maven/org.springframework.webflow/spring-webflow@2.3.4.RELEASE

--- a/statements/CVE-2017-4995/statement.yaml
+++ b/statements/CVE-2017-4995/statement.yaml
@@ -10,7 +10,7 @@ fixes:
     repository: https://github.com/spring-projects/spring-security
 - id: 4.2.x
   commits:
-  - id: 947d11f433b78294942cb5ea56e8aa5c3a0ca43
+  - id: 947d11f433b78294942cb5ea56e8aa5c3a0ca439
     repository: https://github.com/spring-projects/spring-security
 artifacts:
 - id: pkg:maven/org.springframework.security/spring-security-core@4.1.2.RELEASE

--- a/statements/CVE-2017-5637/statement.yaml
+++ b/statements/CVE-2017-5637/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 75411ab34a3d53c43c2d508b12314a9788aa417
+  - id: 75411ab34a3d53c43c2d508b12314a9788aa417d
     repository: https://github.com/apache/zookeeper
 - id: 3.5.4
   commits:
-  - id: 6d9fc04c052adbc79bbbb1c63f3f00c816fb8e5
+  - id: 6d9fc04c052adbc79bbbb1c63f3f00c816fb8e56
     repository: https://github.com/apache/zookeeper
 artifacts:
 - id: pkg:maven/org.apache.zookeeper/zookeeper@3.5.7

--- a/statements/CVE-2017-5643/statement.yaml
+++ b/statements/CVE-2017-5643/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
 - id: "2.17"
   commits:
-  - id: 2c6964ae94d8f9a9c9a32e5ae5a0b794e8b8d3b
+  - id: 2c6964ae94d8f9a9c9a32e5ae5a0b794e8b8d3be
     repository: https://github.com/apache/camel.git
 - id: "2.18"
   commits:
-  - id: 87c92b7b38890c217bc76f2c55036e6a5cca9a0
+  - id: 87c92b7b38890c217bc76f2c55036e6a5cca9a07
     repository: https://github.com/apache/camel.git
-  - id: 9f7376abbff7434794f2c7c2909e02bac232fb5
+  - id: 9f7376abbff7434794f2c7c2909e02bac232fb5b
     repository: https://github.com/apache/camel.git
-  - id: ec3d0db81ba061b27e934d5ff56e9baca0049eb
+  - id: ec3d0db81ba061b27e934d5ff56e9baca0049ebf
     repository: https://github.com/apache/camel.git
 - id: "2.19"
   commits:
-  - id: 8afc5d1757795fde715902067360af5d90f046d
+  - id: 8afc5d1757795fde715902067360af5d90f046da
     repository: https://github.com/apache/camel.git
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-core@2.18.0

--- a/statements/CVE-2017-7233/statement.yaml
+++ b/statements/CVE-2017-7233/statement.yaml
@@ -9,19 +9,19 @@ fixes:
     repository: https://github.com/django/django
 - id: "1.8"
   commits:
-  - id: 8339277518c7d8ec280070a780915304654e3b6
+  - id: 8339277518c7d8ec280070a780915304654e3b66
     repository: https://github.com/django/django
 - id: "1.11"
   commits:
-  - id: 97e77b7bc14eafda704a01881cb2a3dc164947b
+  - id: 97e77b7bc14eafda704a01881cb2a3dc164947bc
     repository: https://github.com/django/django
 - id: "1.10"
   commits:
-  - id: f824655bc2c50b19d2f202d7640785caabc8278
+  - id: f824655bc2c50b19d2f202d7640785caabc82787
     repository: https://github.com/django/django
 - id: "1.9"
   commits:
-  - id: 254326cb3682389f55f886804d2c43f7b9f23e4
+  - id: 254326cb3682389f55f886804d2c43f7b9f23e4f
     repository: https://github.com/django/django
 artifacts:
 - id: pkg:maven/Django/Django@2.0.6

--- a/statements/CVE-2017-7536/statement.yaml
+++ b/statements/CVE-2017-7536/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: "5.4"
   commits:
-  - id: 0778a5c98b817771a645c6f4ba0b28dd8b5437b
+  - id: 0778a5c98b817771a645c6f4ba0b28dd8b5437b8
     repository: https://github.com/hibernate/hibernate-validator
 - id: "5.3"
   commits:
-  - id: 0886e89900d343ea20fde5137c9a3086e6da9ac
+  - id: 0886e89900d343ea20fde5137c9a3086e6da9ac9
     repository: https://github.com/hibernate/hibernate-validator
 - id: "5.2"
   commits:
-  - id: 0ed45f37c4680998167179e631113a2c9cb5d11
+  - id: 0ed45f37c4680998167179e631113a2c9cb5d113
     repository: https://github.com/hibernate/hibernate-validator
 artifacts:
 - id: pkg:maven/org.hibernate.validator/hibernate-validator@6.1.0.Final

--- a/statements/CVE-2017-7561/statement.yaml
+++ b/statements/CVE-2017-7561/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 517db971d8f7094124416bf72091fd0b45a1302
+  - id: 517db971d8f7094124416bf72091fd0b45a13028
     repository: https://github.com/resteasy/Resteasy
 - id: 3.0.19.SPx
   commits:
-  - id: e9a34f2513e75dcaba95e1f2bc6f21668f43985
+  - id: e9a34f2513e75dcaba95e1f2bc6f21668f439855
     repository: https://github.com/resteasy/Resteasy
 - id: 3.0
   commits:
-  - id: fd66aad3cb1e8553323a9af5b58f1ad5150dc5b
+  - id: fd66aad3cb1e8553323a9af5b58f1ad5150dc5b9
     repository: https://github.com/resteasy/Resteasy
 artifacts:
 - id: pkg:maven/org.jboss.resteasy/resteasy-jaxrs@3.5.1.Final

--- a/statements/CVE-2017-7660/statement.yaml
+++ b/statements/CVE-2017-7660/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: branch_5_5
   commits:
-  - id: 2f5ecbcf9ed7a3a4fd37b5c55860ad8eace1bea
+  - id: 2f5ecbcf9ed7a3a4fd37b5c55860ad8eace1beae
     repository: https://git-wip-us.apache.org/repos/asf/lucene-solr
 - id: branch_5x
   commits:
-  - id: 9f91c619a35db89544f5c85795df4128c9f0d96
+  - id: 9f91c619a35db89544f5c85795df4128c9f0d96a
     repository: https://git-wip-us.apache.org/repos/asf/lucene-solr
 - id: branch_6x
   commits:
-  - id: e3b0cfff396a7f92a4f621d598780116da916f3
+  - id: e3b0cfff396a7f92a4f621d598780116da916f3f
     repository: https://git-wip-us.apache.org/repos/asf/lucene-solr
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2017-7669/statement.yaml
+++ b/statements/CVE-2017-7669/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: branch-2.8.1
   commits:
-  - id: bbe3b0857d383c5e4dc4a7ade90a88a3e24338b
+  - id: bbe3b0857d383c5e4dc4a7ade90a88a3e24338b2
     repository: https://github.com/apache/hadoop
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2017-7957/statement.yaml
+++ b/statements/CVE-2017-7957/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: v-1.4.x
   commits:
-  - id: 6e546ec366419158b1e393211be6d78ab9604ab
+  - id: 6e546ec366419158b1e393211be6d78ab9604abe
     repository: https://github.com/x-stream/xstream.git
-  - id: 8542d02d9ac5d384c85f4b33d6c1888c53bd55d
+  - id: 8542d02d9ac5d384c85f4b33d6c1888c53bd55d3
     repository: https://github.com/x-stream/xstream.git
 - id: master
   commits:
-  - id: b3570be2f39234e61f99f9a20640756ea71b1b4
+  - id: b3570be2f39234e61f99f9a20640756ea71b1b40
     repository: https://github.com/x-stream/xstream.git
 artifacts:
 - id: pkg:maven/com.thoughtworks.xstream/xstream@1.4.10-java7

--- a/statements/CVE-2017-8031/statement.yaml
+++ b/statements/CVE-2017-8031/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 3.20.x
   commits:
-  - id: 1e2a746968cdac5b53164ca8955646e4257ecc7
+  - id: 1e2a746968cdac5b53164ca8955646e4257ecc78
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.5.x
   commits:
-  - id: 20808046de8bbdc6fb2ac62829d4cc9d7a19f37
+  - id: 20808046de8bbdc6fb2ac62829d4cc9d7a19f37c
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.7.x
   commits:
-  - id: 66166d17781aa257ff77a2fb7c69f72d0b611be
+  - id: 66166d17781aa257ff77a2fb7c69f72d0b611be3
     repository: https://github.com/cloudfoundry/uaa
 artifacts:
 - id: pkg:maven/org.cloudfoundry.identity/cloudfoundry-identity-server@4.6.1

--- a/statements/CVE-2017-8039/statement.yaml
+++ b/statements/CVE-2017-8039/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 2_5_x
   commits:
-  - id: 084b4
+  - id: 084b4e711c126f7fbb628261e52e07ea85852117
     repository: https://github.com/spring-projects/spring-webflow.git
 - id: "2_4_6"
   commits:
-  - id: df0ea
+  - id: df0eab526abd1f30aa741974f3d472de974c880f
     repository: https://github.com/spring-projects/spring-webflow.git
-  - id: ed5e8
+  - id: ed5e8ce8a5fc18f34274a11a337e31b8a0c72b90
     repository: https://github.com/spring-projects/spring-webflow.git
 artifacts:
 - id: pkg:maven/org.springframework.webflow/spring-webflow@2.3.4.RELEASE

--- a/statements/CVE-2017-8045/statement.yaml
+++ b/statements/CVE-2017-8045/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 1.6.x
   commits:
-  - id: 6e9e00bb5bf0aa88444146db3c2eae138cc7b0a
+  - id: 6e9e00bb5bf0aa88444146db3c2eae138cc7b0a1
     repository: https://github.com/spring-projects/spring-amqp
 - id: 1.5.x
   commits:
-  - id: 83fe9fdec2c86a57898d56c5e109debd9d5c07d
+  - id: 83fe9fdec2c86a57898d56c5e109debd9d5c07d9
     repository: https://github.com/spring-projects/spring-amqp
 - id: 1.7.x
   commits:
-  - id: 296d481f980fcbecbee01244e3644e254470a86
+  - id: 296d481f980fcbecbee01244e3644e254470a86e
     repository: https://github.com/spring-projects/spring-amqp
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2017-8046/statement.yaml
+++ b/statements/CVE-2017-8046/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: 2.6.x
   commits:
-  - id: 824e51a1304bbc8334ac0b96ffaef588177e6cc
+  - id: 824e51a1304bbc8334ac0b96ffaef588177e6ccd
     repository: https://github.com/spring-projects/spring-data-rest
 - id: DEFAULT_BRANCH
   commits:

--- a/statements/CVE-2017-9787/statement.yaml
+++ b/statements/CVE-2017-9787/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: STRUTS_2_3_x
   commits:
-  - id: 086b63735527d4bb0c1dd0d86a7c0374b825ff2
+  - id: 086b63735527d4bb0c1dd0d86a7c0374b825ff24
     repository: https://github.com/apache/struts.git
 - id: STRUTS_2_5_x
   commits:
-  - id: 0d6442bab5b44d93c4c2e63c5335f0a331333b9
+  - id: 0d6442bab5b44d93c4c2e63c5335f0a331333b92
     repository: https://github.com/apache/struts.git
 artifacts:
 - id: pkg:maven/org.apache.struts/struts2-core@2.3.15

--- a/statements/CVE-2017-9804/statement.yaml
+++ b/statements/CVE-2017-9804/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
   - id: support-2-3
     commits:
-      - id: 3fddfb6eb562d597c935084e9e81d43ed6bcd02
+      - id: 3fddfb6eb562d597c935084e9e81d43ed6bcd02c
         repository: https://gitbox.apache.org/repos/asf/struts.git
-      - id: 744c1f409d983641af3e8e3b573c2f2d2c2c6d9
+      - id: 744c1f409d983641af3e8e3b573c2f2d2c2c6d9c
         repository: https://gitbox.apache.org/repos/asf/struts.git
   - id: master
     commits:
-      - id: 418a20c0594f23764fe29ced400c1219239899a
+      - id: 418a20c0594f23764fe29ced400c1219239899a8
         repository: https://gitbox.apache.org/repos/asf/struts.git
-      - id: 8a04e80f01350c90f053d71366d5e0c2186fded
+      - id: 8a04e80f01350c90f053d71366d5e0c2186fded5
         repository: https://gitbox.apache.org/repos/asf/struts.git
-      - id: 9d47af6ffa355977b5acc713e6d1f25fac260a2
+      - id: 9d47af6ffa355977b5acc713e6d1f25fac260a28
         repository: https://gitbox.apache.org/repos/asf/struts.git
-      - id: a05259ed69a5a48379aa91650e4cd1cb4bd6e5a
+      - id: a05259ed69a5a48379aa91650e4cd1cb4bd6e5ad
         repository: https://gitbox.apache.org/repos/asf/struts.git
 artifacts:
   - id: pkg:maven/org.apache.struts/struts2-core@2.3.15

--- a/statements/CVE-2017-9805/statement.yaml
+++ b/statements/CVE-2017-9805/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
   - id: master
     commits:
-      - id: 19494718865f2fb7da5ea363de3822f87fbda26
+      - id: 19494718865f2fb7da5ea363de3822f87fbda264
         repository: https://gitbox.apache.org/repos/asf/struts.git
   - id: support-2-3
     commits:
-      - id: 6dd6e5cfb7b5e020abffe7e8091bd63fe97c10a
+      - id: 6dd6e5cfb7b5e020abffe7e8091bd63fe97c10af
         repository: https://gitbox.apache.org/repos/asf/struts.git
 artifacts:
   - id: pkg:maven/org.apache.struts/struts2-rest-plugin@2.3.34

--- a/statements/CVE-2018-1000130/statement.yaml
+++ b/statements/CVE-2018-1000130/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 1b360b8889f0ed51165a8d1ac55dd8e0aa2dfd4
+  - id: 1b360b8889f0ed51165a8d1ac55dd8e0aa2dfd4a
     repository: https://github.com/rhuss/jolokia
-  - id: fd7b93da30c61a45bac10d8b311f1b79a74910f
+  - id: fd7b93da30c61a45bac10d8b311f1b79a74910f5
     repository: https://github.com/rhuss/jolokia
 artifacts:
 - id: pkg:maven/org.jolokia/jolokia-core@1.5.0

--- a/statements/CVE-2018-1067/statement.yaml
+++ b/statements/CVE-2018-1067/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: "1.4"
   commits:
-  - id: 85d4478e598105fe94ac152d3e11e388374e8b8
+  - id: 85d4478e598105fe94ac152d3e11e388374e8b86
     repository: https://github.com/undertow-io/undertow
 - id: 2.0.7
   commits:
-  - id: f404cb68448c188f4d51b085b7fe4ac32bde26e
+  - id: f404cb68448c188f4d51b085b7fe4ac32bde26e0
     repository: https://github.com/undertow-io/undertow
 artifacts:
 - id: pkg:maven/io.undertow/undertow-core@2.0.26.Final

--- a/statements/CVE-2018-11040/statement.yaml
+++ b/statements/CVE-2018-11040/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 4.3.x
   commits:
-  - id: 874859493bbda59739c38c7e52eb3625f247b93
+  - id: 874859493bbda59739c38c7e52eb3625f247b93a
     repository: https://github.com/spring-projects/spring-framework
 - id: 5.0.x
   commits:
-  - id: b80c13b722bb207ddf43f53a007ee3ddc1dd2e2
+  - id: b80c13b722bb207ddf43f53a007ee3ddc1dd2e26
     repository: https://github.com/spring-projects/spring-framework
 artifacts:
 - id: pkg:maven/org.springframework/spring-websocket@5.1.10.RELEASE

--- a/statements/CVE-2018-11041/statement.yaml
+++ b/statements/CVE-2018-11041/statement.yaml
@@ -4,21 +4,21 @@ notes:
 fixes:
 - id: 4.7.x
   commits:
-  - id: d17b23fc3bf9b86f111774925afadfced75315c
+  - id: d17b23fc3bf9b86f111774925afadfced75315c0
     repository: https://github.com/cloudfoundry/uaa
-  - id: 57a15dfb7e0e3a59019ebe951793b586512b196
+  - id: 57a15dfb7e0e3a59019ebe951793b586512b1962
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.19.0
   commits:
-  - id: f6362a8f1865314aa507fc5de772848b7e55236
+  - id: f6362a8f1865314aa507fc5de772848b7e552365
     repository: https://github.com/cloudfoundry/uaa
-  - id: 7a8f157f7e2feed2d0ebb63b163ff735b6340b9
+  - id: 7a8f157f7e2feed2d0ebb63b163ff735b6340b96
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.10.x
   commits:
-  - id: 7d750e036cd52c5d30e73e28cbcae23126d7154
+  - id: 7d750e036cd52c5d30e73e28cbcae23126d7154b
     repository: https://github.com/cloudfoundry/uaa
-  - id: 8a599448781acd481aa9dab1b0bde3424e00ced
+  - id: 8a599448781acd481aa9dab1b0bde3424e00ced4
     repository: https://github.com/cloudfoundry/uaa
 artifacts:
 - id: pkg:maven/org.cloudfoundry.identity/cloudfoundry-identity-server@4.6.1

--- a/statements/CVE-2018-11047/statement.yaml
+++ b/statements/CVE-2018-11047/statement.yaml
@@ -4,23 +4,23 @@ notes:
 fixes:
 - id: 4.12.4
   commits:
-  - id: bbbba5aec514ad88e7d1e168a2519c80229f02f
+  - id: bbbba5aec514ad88e7d1e168a2519c80229f02ff
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.19.2
   commits:
-  - id: 2906057dae995024576ce6afdc20abd85569514
+  - id: 2906057dae995024576ce6afdc20abd855695141
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.10.2
   commits:
-  - id: 81aeb7a3aa048ea086c494f725d643e48dd9266
+  - id: 81aeb7a3aa048ea086c494f725d643e48dd92669
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.5.7
   commits:
-  - id: a1d523c7f150e56bf06df8b83ed1d416d6c1d3b
+  - id: a1d523c7f150e56bf06df8b83ed1d416d6c1d3bb
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.7.6
   commits:
-  - id: aba1fb5f18e0d628628b2d960fc6d0cc62d86f5
+  - id: aba1fb5f18e0d628628b2d960fc6d0cc62d86f53
     repository: https://github.com/cloudfoundry/uaa
 artifacts:
 - id: pkg:maven/org.cloudfoundry.identity/cloudfoundry-identity-server@4.6.1

--- a/statements/CVE-2018-11087/statement.yaml
+++ b/statements/CVE-2018-11087/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 2.1.0
   commits:
-  - id: 444b74e95bb299af5e23ebf006fbb45d574fb95
+  - id: 444b74e95bb299af5e23ebf006fbb45d574fb95e
     repository: https://github.com/spring-projects/spring-amqp
 - id: 1.7.10
   commits:
-  - id: aff4d0aefcdb99726fd739abf3b9bb96df97b0f
+  - id: aff4d0aefcdb99726fd739abf3b9bb96df97b0fa
     repository: https://github.com/spring-projects/spring-amqp
 - id: 2.0.6
   commits:
-  - id: d64e7fa3993dac577c0973e0caf8c31d27ef5e4
+  - id: d64e7fa3993dac577c0973e0caf8c31d27ef5e44
     repository: https://github.com/spring-projects/spring-amqp
 artifacts:
 - id: pkg:maven/org.springframework.amqp/spring-rabbit@2.0.10.RELEASE

--- a/statements/CVE-2018-1114/statement.yaml
+++ b/statements/CVE-2018-1114/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.0.5
   commits:
-  - id: 882d5884f2614944a0c2ae69bafd9d13bfc5b64
+  - id: 882d5884f2614944a0c2ae69bafd9d13bfc5b64a
     repository: https://github.com/undertow-io/undertow
 - id: 1.4.x
   commits:
-  - id: 7f22aa0090296eb00280f878e3731bb71d40f9e
+  - id: 7f22aa0090296eb00280f878e3731bb71d40f9eb
     repository: https://github.com/undertow-io/undertow
 artifacts:
 - id: pkg:maven/io.undertow/undertow-core@2.0.26.Final

--- a/statements/CVE-2018-11307/statement.yaml
+++ b/statements/CVE-2018-11307/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.8.11.2
   commits:
-  - id: 051bd5e447fbc9539e12a4fe90eb989dba0c656
+  - id: 051bd5e447fbc9539e12a4fe90eb989dba0c656e
     repository: https://github.com/FasterXML/jackson-databind
 - id: 2.7.9.4
   commits:
-  - id: 27b4defc270454dea6842bd9279f17387eceb73
+  - id: 27b4defc270454dea6842bd9279f17387eceb737
     repository: https://github.com/FasterXML/jackson-databind
 artifacts:
 - id: pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.1.2

--- a/statements/CVE-2018-11768/statement.yaml
+++ b/statements/CVE-2018-11768/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: branch-2.9
   commits:
-  - id: eeeea1d75d69d4619955e6b5ab5a7db18ee252b
+  - id: eeeea1d75d69d4619955e6b5ab5a7db18ee252b3
     repository: https://github.com/apache/hadoop
 - id: branch-3.1
   commits:
-  - id: 96cedb87b94c07c11152580bf36978186d622b5
+  - id: 96cedb87b94c07c11152580bf36978186d622b50
     repository: https://github.com/apache/hadoop
 - id: branch-2.8
   commits:    
-  - id: a868fb1c8fab1be927654b453b2eb9d98cb3066
+  - id: a868fb1c8fab1be927654b453b2eb9d98cb3066a
     repository: https://github.com/apache/hadoop
 artifacts:
 - id: pkg:maven/org.apache.hadoop/hadoop-hdfs-client@3.1.2

--- a/statements/CVE-2018-11776/statement.yaml
+++ b/statements/CVE-2018-11776/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 2.3.x
   commits:
-  - id: 4a3917176de2df7f33a85511d067f31e50dcc1b
+  - id: 4a3917176de2df7f33a85511d067f31e50dcc1b2
     repository: https://github.com/apache/struts
 - id: 2.5.x
   commits:
-  - id: b3bad5ea44f3fd9edb2cb491192c5900f46d45d
+  - id: b3bad5ea44f3fd9edb2cb491192c5900f46d45d3
     repository: https://github.com/apache/struts
-  - id: 6e87474f9ad0549f07dd2c37d50a9ccd0977c6e
+  - id: 6e87474f9ad0549f07dd2c37d50a9ccd0977c6e5
     repository: https://github.com/apache/struts
-  - id: 6efaf900d4ffb7be8a74065af5553bad2389f72
+  - id: 6efaf900d4ffb7be8a74065af5553bad2389f729
     repository: https://github.com/apache/struts
 artifacts:
 - id: pkg:maven/org.apache.struts/struts2-core@2.0.5

--- a/statements/CVE-2018-11777/statement.yaml
+++ b/statements/CVE-2018-11777/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 00c0ee7bc4b8492476b377a6edafcc33411f14b
+  - id: 00c0ee7bc4b8492476b377a6edafcc33411f14b6
     repository: https://github.com/apache/hive
 - id: branch-2.3
   commits:
-  - id: 1a1d6ca1bc3ae840238dc345fa1eb2c7c28c8cb
+  - id: 1a1d6ca1bc3ae840238dc345fa1eb2c7c28c8cb0
     repository: https://github.com/apache/hive
 - id: branch-3.1
   commits:
-  - id: f0419dfaabe31dd7802c37aeebab101265907e1
+  - id: f0419dfaabe31dd7802c37aeebab101265907e1a
     repository: https://github.com/apache/hive
 artifacts:
 - id: pkg:maven/org.apache.hive/hive-exec@1.2.1

--- a/statements/CVE-2018-11787/statement.yaml
+++ b/statements/CVE-2018-11787/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: 4.0.9
   commits:
-  - id: 434e52502528e91e20d2f87cec7732f1e6e554c
+  - id: 434e52502528e91e20d2f87cec7732f1e6e554c2
     repository: https://github.com/apache/karaf
 - id: 4.1.1
   commits:
-  - id: cfa213ad680ded70b70bf0c648891a06386ef63
+  - id: cfa213ad680ded70b70bf0c648891a06386ef632
     repository: https://github.com/apache/karaf

--- a/statements/CVE-2018-11788/statement.yaml
+++ b/statements/CVE-2018-11788/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 4.2.2
   commits:
-  - id: 0c36c50bc158739c8fc8543122a6740c54adafc
+  - id: 0c36c50bc158739c8fc8543122a6740c54adafca
     repository: https://github.com/apache/karaf
 - id: 4.1.7
   commits:
-  - id: 1ffa6d1c4555cab9737d76b49142528b57cfdfc
+  - id: 1ffa6d1c4555cab9737d76b49142528b57cfdfc4
     repository: https://github.com/apache/karaf
 artifacts:
 - id: pkg:maven/stax/stax-api@1.0

--- a/statements/CVE-2018-11802/statement.yaml
+++ b/statements/CVE-2018-11802/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 000d0c1364b4c39d53095b37f263f75880d432d
+  - id: 000d0c1364b4c39d53095b37f263f75880d432db
     repository: https://github.com/apache/lucene-solr
-  - id: 619b38a19bbfb32e6b99df04060b15b249aaab7
+  - id: 619b38a19bbfb32e6b99df04060b15b249aaab7a
     repository: https://github.com/apache/lucene-solr
-  - id: add003f217806afb4e1604f697cdb0a5a711589
+  - id: add003f217806afb4e1604f697cdb0a5a7115895
     repository: https://github.com/apache/lucene-solr
-  - id: d14bf2dc1ab0fd9d27d8add9ead1a7a76f4f340
+  - id: d14bf2dc1ab0fd9d27d8add9ead1a7a76f4f340f
     repository: https://github.com/apache/lucene-solr
-  - id: e085fcd3f5952018e6bf465e4a6274b560bdee2
+  - id: e085fcd3f5952018e6bf465e4a6274b560bdee22
     repository: https://github.com/apache/lucene-solr
 artifacts:
 - id: pkg:maven/org.apache.solr/solr-core@7.1.0

--- a/statements/CVE-2018-12022/statement.yaml
+++ b/statements/CVE-2018-12022/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.7.9
   commits:
-  - id: 28badf7ef60ac3e7ef151cd8e8ec010b8479226
+  - id: 28badf7ef60ac3e7ef151cd8e8ec010b8479226a
     repository: https://github.com/FasterXML/jackson-databind
 - id: 2.8.11
   commits:
-  - id: 7487cf7eb14be2f65a1eb108e8629c07ef45e0a
+  - id: 7487cf7eb14be2f65a1eb108e8629c07ef45e0a1
     repository: https://github.com/FasterXML/jackson-databind
 artifacts:
 - id: pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.1.1

--- a/statements/CVE-2018-12023/statement.yaml
+++ b/statements/CVE-2018-12023/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.7.9
   commits:
-  - id: 28badf7ef60ac3e7ef151cd8e8ec010b8479226
+  - id: 28badf7ef60ac3e7ef151cd8e8ec010b8479226a
     repository: https://github.com/FasterXML/jackson-databind
 - id: 2.8.11
   commits:
-  - id: 7487cf7eb14be2f65a1eb108e8629c07ef45e0a
+  - id: 7487cf7eb14be2f65a1eb108e8629c07ef45e0a1
     repository: https://github.com/FasterXML/jackson-databind
 artifacts:
 - id: pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.1.2

--- a/statements/CVE-2018-12536/statement.yaml
+++ b/statements/CVE-2018-12536/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 9.3.x
   commits:
-  - id: 53e8bc2a636707e896fd106fbee3596823c2cdc
+  - id: 53e8bc2a636707e896fd106fbee3596823c2cdc9
     repository: https://github.com/eclipse/jetty.project
 - id: 9.4.x
   commits:
-  - id: a51920d650d924cc2cea011995624b394437c6e
+  - id: a51920d650d924cc2cea011995624b394437c6e0
     repository: https://github.com/eclipse/jetty.project
 artifacts:
 - id: pkg:maven/org.eclipse.jetty/jetty-server@9.4.26.v20200117

--- a/statements/CVE-2018-12540/statement.yaml
+++ b/statements/CVE-2018-12540/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 98891b1d9e022b467a3e4674aca4d1889849b1d
+  - id: 98891b1d9e022b467a3e4674aca4d1889849b1d5
     repository: https://github.com/vert-x3/vertx-web
 - id: 3.5.3
   commits:
-  - id: f42b193b15a29b772fc576b2d0f2497e7474a7e
+  - id: f42b193b15a29b772fc576b2d0f2497e7474a7e9
     repository: https://github.com/vert-x3/vertx-web
 artifacts:
 - id: pkg:maven/io.vertx/vertx-web@3.0.0

--- a/statements/CVE-2018-12544/statement.yaml
+++ b/statements/CVE-2018-12544/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: 3.5.3
   commits:
-  - id: ac8692c618d6180a9bc012a2ac8dbec821b1a97
+  - id: ac8692c618d6180a9bc012a2ac8dbec821b1a973
     repository: https://github.com/vert-x3/vertx-web
 - id: 3.5.1
   commits:
-  - id: d814d22ade14bafec47c4447a4ba9bff090f05e
+  - id: d814d22ade14bafec47c4447a4ba9bff090f05e8
     repository: https://github.com/vert-x3/vertx-web

--- a/statements/CVE-2018-1257/statement.yaml
+++ b/statements/CVE-2018-1257/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 4.3.x
   commits:
-  - id: 246a6db1cad205ca9b6fca00c544ab7443ba202
+  - id: 246a6db1cad205ca9b6fca00c544ab7443ba202c
     repository: https://github.com/spring-projects/spring-framework
 - id: 5.0.x
   commits:
-  - id: ff2228fdaf131d57b5c8c5918ee8d07c6dd9bba
+  - id: ff2228fdaf131d57b5c8c5918ee8d07c6dd9bbac
     repository: https://github.com/spring-projects/spring-framework
 artifacts:
 - id: pkg:maven/org.springframework/spring-messaging@4.3.17.RELEASE

--- a/statements/CVE-2018-1258/statement.yaml
+++ b/statements/CVE-2018-1258/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 5.0.5
   commits:
-  - id: 7b8fa90d96aaf751a3256fa755d5f17e081c20f
+  - id: 7b8fa90d96aaf751a3256fa755d5f17e081c20f1
     repository: https://github.com/spring-projects/spring-security
 - id: master
   commits:
-  - id: fed15f2b01b763158f6650afa13059203366974
+  - id: fed15f2b01b763158f6650afa130592033669740
     repository: https://github.com/spring-projects/spring-security
 artifacts:
 - id: pkg:maven/org.springframework.security/spring-security-config@5.1.1.RELEASE

--- a/statements/CVE-2018-1260/statement.yaml
+++ b/statements/CVE-2018-1260/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
 - id: 2.0.15
   commits:
-  - id: 1c6815ac1b26fb2f079adbe283c43a7fd0885f3
+  - id: 1c6815ac1b26fb2f079adbe283c43a7fd0885f3d
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.1.2
   commits:
-  - id: 6b1791179c1092553aa0690da22dac4dff2fc58
+  - id: 6b1791179c1092553aa0690da22dac4dff2fc58d
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.2.2
   commits:
-  - id: 8e9792c1963f1aeea81ca618785eb8d71d1cd1d
+  - id: 8e9792c1963f1aeea81ca618785eb8d71d1cd1d2
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.3.3
   commits:
-  - id: adb1e6d19c681f394c9513799b81b527b0cb007
+  - id: adb1e6d19c681f394c9513799b81b527b0cb007c
     repository: https://github.com/spring-projects/spring-security-oauth
 artifacts:
 - id: pkg:maven/org.springframework.security.oauth/spring-security-oauth2@2.0.15.RELEASE

--- a/statements/CVE-2018-1262/statement.yaml
+++ b/statements/CVE-2018-1262/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 4.12.2
   commits:
-  - id: 14c745aa293b8d3ce9cdd6bfbc6c0ef3f269b21
+  - id: 14c745aa293b8d3ce9cdd6bfbc6c0ef3f269b211
     repository: https://github.com/cloudfoundry/uaa
-  - id: 4178762a49f547534b13539ca65e1d370772c38
+  - id: 4178762a49f547534b13539ca65e1d370772c388
     repository: https://github.com/cloudfoundry/uaa
 - id: 4.13.4
   commits:
-  - id: 3633a832885ebf33b2e22cc1c0c8ce605e2c657
+  - id: 3633a832885ebf33b2e22cc1c0c8ce605e2c657d
     repository: https://github.com/cloudfoundry/uaa
-  - id: dccd3962f969913996ee88f653fce3b108c0205
+  - id: dccd3962f969913996ee88f653fce3b108c0205b
     repository: https://github.com/cloudfoundry/uaa
 artifacts:
 - id: pkg:maven/org.cloudfoundry.identity/cloudfoundry-identity-server@4.11.0

--- a/statements/CVE-2018-1270/statement.yaml
+++ b/statements/CVE-2018-1270/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 5.x
   commits:
-  - id: 1db7e02de3eb0c011ee6681f5a12eb9d166fea8
+  - id: 1db7e02de3eb0c011ee6681f5a12eb9d166fea81
     repository: https://github.com/spring-projects/spring-framework
-  - id: e0de9126ed8cf25cf141d3e66420da94e350708
+  - id: e0de9126ed8cf25cf141d3e66420da94e350708a
     repository: https://github.com/spring-projects/spring-framework
 - id: 4.x
   commits:
-  - id: d3acf45ea4db51fa5c4cbd0bc0e7b6d9ef805e6
+  - id: d3acf45ea4db51fa5c4cbd0bc0e7b6d9ef805e69
     repository: https://github.com/spring-projects/spring-framework
 artifacts:
 - id: pkg:maven/org.springframework/spring-messaging@4.3.17.RELEASE

--- a/statements/CVE-2018-1271/statement.yaml
+++ b/statements/CVE-2018-1271/statement.yaml
@@ -4,21 +4,21 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 98ad23bef8e2e04143f8f5b201380543a8d8c0c
+  - id: 98ad23bef8e2e04143f8f5b201380543a8d8c0c3
     repository: https://github.com/spring-projects/spring-framework
-  - id: f59ea610dfcf55cd0b42f6dd76a9b3dab0218aa
+  - id: f59ea610dfcf55cd0b42f6dd76a9b3dab0218aaa
     repository: https://github.com/spring-projects/spring-framework
-  - id: 0e28bee0f155b9bf240b4bafc4646e4810cb23f
+  - id: 0e28bee0f155b9bf240b4bafc4646e4810cb23f8
     repository: https://github.com/spring-projects/spring-framework
-  - id: 13356a7ee2240f740737c5c83bdccdacc30603a
+  - id: 13356a7ee2240f740737c5c83bdccdacc30603ab
     repository: https://github.com/spring-projects/spring-framework
-  - id: 91b803a2310344d925e5d4b1709bbcea9037554
+  - id: 91b803a2310344d925e5d4b1709bbcea90375548
     repository: https://github.com/spring-projects/spring-framework
-  - id: 695bf2961feffd35b5560ccc982a2189dcca611
+  - id: 695bf2961feffd35b5560ccc982a2189dcca611f
     repository: https://github.com/spring-projects/spring-framework
 - id: 4.3.x
   commits:
-  - id: b9ebdaaf3710db473a2e1fec8641c316483a22a
+  - id: b9ebdaaf3710db473a2e1fec8641c316483a22aa
     repository: https://github.com/spring-projects/spring-framework
 artifacts:
 - id: pkg:maven/org.springframework/spring-webflux@5.2.4.RELEASE

--- a/statements/CVE-2018-1272/statement.yaml
+++ b/statements/CVE-2018-1272/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 5.0.5
   commits:
-  - id: ab2410c754b67902f002bfcc0c3895bd7772d39
+  - id: ab2410c754b67902f002bfcc0c3895bd7772d39f
     repository: https://github.com/spring-projects/spring-framework
 - id: 4.3.x
   commits:
-  - id: e02ff3a0da50744b0980d5d665fd242eedea767
+  - id: e02ff3a0da50744b0980d5d665fd242eedea7675
     repository: https://github.com/spring-projects/spring-framework
 artifacts:
 - id: pkg:maven/org.springframework/spring-core@5.1.6.RELEASE

--- a/statements/CVE-2018-1273/statement.yaml
+++ b/statements/CVE-2018-1273/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.0.x
   commits:
-  - id: ae1dd2741ce06d44a0966ecbd6f47beabde2b65
+  - id: ae1dd2741ce06d44a0966ecbd6f47beabde2b653
     repository: https://github.com/spring-projects/spring-data-commons
 - id: 1.13.x
   commits:
-  - id: b1a20ae1e82a63f99b3afc6f2aaedb3bf4dc432
+  - id: b1a20ae1e82a63f99b3afc6f2aaedb3bf4dc432a
     repository: https://github.com/spring-projects/spring-data-commons
 artifacts:
 - id: pkg:maven/org.springframework.data/spring-data-commons@1.12.11.RELEASE

--- a/statements/CVE-2018-1274/statement.yaml
+++ b/statements/CVE-2018-1274/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 1.13.x
   commits:
-  - id: 371f6590c509c72f8e600f3d05e110941607fba
+  - id: 371f6590c509c72f8e600f3d05e110941607fbad
     repository: https://github.com/spring-projects/spring-data-commons
 - id: 2.0.x
   commits:
-  - id: 3d8576fe4e4e71c23b9e6796b32fd56e51182ee
+  - id: 3d8576fe4e4e71c23b9e6796b32fd56e51182ee0
     repository: https://github.com/spring-projects/spring-data-commons
 artifacts:
 - id: pkg:maven/org.springframework.data/spring-data-commons@1.12.9.RELEASE

--- a/statements/CVE-2018-1275/statement.yaml
+++ b/statements/CVE-2018-1275/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 5.x
   commits:
-  - id: 1db7e02de3eb0c011ee6681f5a12eb9d166fea8
+  - id: 1db7e02de3eb0c011ee6681f5a12eb9d166fea81
     repository: https://github.com/spring-projects/spring-framework
 - id: 4.x
   commits:
-  - id: d3acf45ea4db51fa5c4cbd0bc0e7b6d9ef805e6
+  - id: d3acf45ea4db51fa5c4cbd0bc0e7b6d9ef805e69
     repository: https://github.com/spring-projects/spring-framework
 artifacts:
 - id: pkg:maven/org.springframework/spring-expression@4.3.21.RELEASE

--- a/statements/CVE-2018-1282/statement.yaml
+++ b/statements/CVE-2018-1282/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: "2.3"
   commits:
-  - id: 63df42966cf44ffdd20d3fcdcfb70738c0432ab
+  - id: 63df42966cf44ffdd20d3fcdcfb70738c0432aba
     repository: https://github.com/apache/hive
 - id: "2.6"
   commits:
-  - id: 0330c1c0b62f3c2e6a4744048578dea55193b62
+  - id: 0330c1c0b62f3c2e6a4744048578dea55193b62c
     repository: https://github.com/apache/hive
 artifacts:
 - id: pkg:maven/org.apache.hive/hive-jdbc@2.1.1

--- a/statements/CVE-2018-1308/statement.yaml
+++ b/statements/CVE-2018-1308/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 02c693f3713add1b4891cbaa87127de3a55c10f
+  - id: 02c693f3713add1b4891cbaa87127de3a55c10f7
     repository: https://github.com/apache/lucene-solr
 - id: 7.3.0
   commits:
-  - id: 739a79338856599084617d44b6a1b424af059aa
+  - id: 739a79338856599084617d44b6a1b424af059aa1
     repository: https://github.com/apache/lucene-solr
 - id: 6.3.3
   commits:
-  - id: dd3be31f7062dcb2f3b2d7f0e89df29e197dee6
+  - id: dd3be31f7062dcb2f3b2d7f0e89df29e197dee63
     repository: https://github.com/apache/lucene-solr
 artifacts:
 - id: pkg:maven/org.apache.solr/solr-dataimporthandler@7.1.0

--- a/statements/CVE-2018-1321/statement.yaml
+++ b/statements/CVE-2018-1321/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 2.0.8
   commits:
-  - id: ad31479c1c543ac7d26b8c882aa14f6c00c1fd0
+  - id: ad31479c1c543ac7d26b8c882aa14f6c00c1fd0a
     repository: https://github.com/apache/syncope
 - id: master
   commits:
-  - id: 717289bc10b6f3b204cb6d14881f530174c6235
+  - id: 717289bc10b6f3b204cb6d14881f530174c62359
     repository: https://github.com/apache/syncope
 - id: 1.2.11
   commits:
-  - id: 726231fbf7b817bd2a9467171dcb1c0087c75bc
+  - id: 726231fbf7b817bd2a9467171dcb1c0087c75bc6
     repository: https://github.com/apache/syncope

--- a/statements/CVE-2018-1322/statement.yaml
+++ b/statements/CVE-2018-1322/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 1.2.11
   commits:
-  - id: 44a5ca0fbd357b8b5d81aa9313fb01cca30d8ad
+  - id: 44a5ca0fbd357b8b5d81aa9313fb01cca30d8ad3
     repository: https://github.com/apache/syncope
 - id: 2.0.8
   commits:
-  - id: 735579b6f987b407049ac1f1da08e675d957c3e
+  - id: 735579b6f987b407049ac1f1da08e675d957c3e6
     repository: https://github.com/apache/syncope
 - id: master
   commits:
-  - id: 7b168c142b09c3b03e39f1449211e7ddf026a14
+  - id: 7b168c142b09c3b03e39f1449211e7ddf026a14d
     repository: https://github.com/apache/syncope

--- a/statements/CVE-2018-1325/statement.yaml
+++ b/statements/CVE-2018-1325/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 6.x
   commits:
-  - id: 22e414d693e8ef679ac6da38107fbc118a63f00
+  - id: 22e414d693e8ef679ac6da38107fbc118a63f006
     repository: https://github.com/sebfz1/wicket-jquery-ui
 - id: 7.10.2
   commits:
-  - id: 2fec03dbe2f6e8808f4bdc6b3195dff3e44f520
+  - id: 2fec03dbe2f6e8808f4bdc6b3195dff3e44f520e
     repository: https://github.com/sebfz1/wicket-jquery-ui
 - id: 8.x
   commits:
-  - id: 4ade74d87389935dee5ba49b8cdd0abb075cc50
+  - id: 4ade74d87389935dee5ba49b8cdd0abb075cc506
     repository: https://github.com/sebfz1/wicket-jquery-ui

--- a/statements/CVE-2018-1331/statement.yaml
+++ b/statements/CVE-2018-1331/statement.yaml
@@ -4,17 +4,17 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 8ffa920d3894634aa078f0fdf6b02d270262caf
+  - id: 8ffa920d3894634aa078f0fdf6b02d270262caf4
     repository: https://github.com/apache/storm
 - id: "1.0"
   commits:
-  - id: a6bf3e421d3d37a797e3bb374fcd20a00189feb
+  - id: a6bf3e421d3d37a797e3bb374fcd20a00189feb4
     repository: https://github.com/apache/storm
 - id: "1.2"
   commits:
-  - id: e3652b44a377436256f77a2749ed133bbafd2fb
+  - id: e3652b44a377436256f77a2749ed133bbafd2fbf
     repository: https://github.com/apache/storm
 - id: "1.1"
   commits:
-  - id: 22a962073c5f12dc5ab281a15d93eb5efc31ab6
+  - id: 22a962073c5f12dc5ab281a15d93eb5efc31ab6b
     repository: https://github.com/apache/storm

--- a/statements/CVE-2018-1337/statement.yaml
+++ b/statements/CVE-2018-1337/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: "2.0"
   commits:
-  - id: 075b70a733d7af150b3d85684149ff5f029f7fd
+  - id: 075b70a733d7af150b3d85684149ff5f029f7fd4
     repository: https://github.com/apache/directory-ldap-api
 - id: 1.0.x
   commits:
-  - id: 5faa6a71606a22a7503d401911875ec3a355cac
+  - id: 5faa6a71606a22a7503d401911875ec3a355cac9
     repository: https://github.com/apache/directory-ldap-api

--- a/statements/CVE-2018-14642/statement.yaml
+++ b/statements/CVE-2018-14642/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.0.15
   commits:
-  - id: c46b7b49c5a561731c84a76ee52244369af1af8
+  - id: c46b7b49c5a561731c84a76ee52244369af1af8a
     repository: https://github.com/undertow-io/undertow
 - id: 1.4.27
   commits:
-  - id: dc22648efe16968242df5d793e3418afafcb36c
+  - id: dc22648efe16968242df5d793e3418afafcb36c0
     repository: https://github.com/undertow-io/undertow
 artifacts:
 - id: pkg:maven/io.undertow/undertow-core@2.0.26.Final

--- a/statements/CVE-2018-15756/statement.yaml
+++ b/statements/CVE-2018-15756/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 5.0.10
   commits:
-  - id: c8e320019ffe7298fc4cbeeb194b2bfd6389b6d
+  - id: c8e320019ffe7298fc4cbeeb194b2bfd6389b6d9
     repository: https://github.com/spring-projects/spring-framework
 - id: 4.3.10
   commits:
-  - id: 044772641d12b9281185f6cf50f8485b8747132
+  - id: 044772641d12b9281185f6cf50f8485b8747132c
     repository: https://github.com/spring-projects/spring-framework
 - id: 5.1.1
   commits:
-  - id: 423aa28ed584b4ff6e5bad218c09beef5e91951
+  - id: 423aa28ed584b4ff6e5bad218c09beef5e91951e
     repository: https://github.com/spring-projects/spring-framework
 artifacts:
 - id: pkg:maven/org.springframework/spring-web@3.1.1.RELEASE

--- a/statements/CVE-2018-15758/statement.yaml
+++ b/statements/CVE-2018-15758/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
 - id: 2.3.4
   commits:
-  - id: 4082ec7ae3d39198a47b5c803ccb20dacefb0b0
+  - id: 4082ec7ae3d39198a47b5c803ccb20dacefb0b09
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.0.16
   commits:
-  - id: 623776689fdcc8047f5a908c71f348e1f172a97
+  - id: 623776689fdcc8047f5a908c71f348e1f172a97f
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.1.3
   commits:
-  - id: ddd65cd9417ae1e4a69e4193a622300db38e2ef
+  - id: ddd65cd9417ae1e4a69e4193a622300db38e2ef1
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.2.3
   commits:
-  - id: f92223afc71687bd3156298054903f50aa71fbf
+  - id: f92223afc71687bd3156298054903f50aa71fbf9
     repository: https://github.com/spring-projects/spring-security-oauth
 artifacts:
 - id: pkg:maven/org.springframework.security.oauth/spring-security-oauth2@2.0.15.RELEASE

--- a/statements/CVE-2018-17184/statement.yaml
+++ b/statements/CVE-2018-17184/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 2.0.11
   commits:
-  - id: 73aed0a741b1255f45893e3cada650147335073
+  - id: 73aed0a741b1255f45893e3cada6501473350738
     repository: https://github.com/apache/syncope
 - id: 2.1.0
   commits:
-  - id: b25a8834db2cc7ea45707a1218e85e047568427
+  - id: b25a8834db2cc7ea45707a1218e85e0475684270
     repository: https://github.com/apache/syncope
 - id: master
   commits:
-  - id: 36fb466afd64894170fa5e2e030ce6895120b1a
+  - id: 36fb466afd64894170fa5e2e030ce6895120b1af
     repository: https://github.com/apache/syncope

--- a/statements/CVE-2018-17186/statement.yaml
+++ b/statements/CVE-2018-17186/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 2.1.2
   commits:
-  - id: a0f35f45f8ca5c98853ae8477fb2db81a84709a
+  - id: a0f35f45f8ca5c98853ae8477fb2db81a84709a1
     repository: https://github.com/apache/syncope
 - id: master
   commits:
-  - id: bdb6a180dcae6f1baaff16619cb906b7292da0d
+  - id: bdb6a180dcae6f1baaff16619cb906b7292da0d1
     repository: https://github.com/apache/syncope
 - id: 2.0.11
   commits:
-  - id: 979c28abf2587c73b57d20e4b892410fdd336f0
+  - id: 979c28abf2587c73b57d20e4b892410fdd336f06
     repository: https://github.com/apache/syncope

--- a/statements/CVE-2018-19586/statement.yaml
+++ b/statements/CVE-2018-19586/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 3ca3103ebc0813a3b2b4bcb89ca12f5257696e2
+  - id: 3ca3103ebc0813a3b2b4bcb89ca12f5257696e2b
     repository: https://github.com/Silverpeas/Silverpeas-Core
 - id: "5.15"
   commits:
-  - id: 817f3c7ea3895aececff1e2e3bd3bb9f9564d04
+  - id: 817f3c7ea3895aececff1e2e3bd3bb9f9564d048
     repository: https://github.com/Silverpeas/Silverpeas-Core

--- a/statements/CVE-2018-5968/statement.yaml
+++ b/statements/CVE-2018-5968/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: 2.8.11.1
   commits:
-  - id: 038b471e2efde2e8f96b4e0be958d3e5a1ff1d0
+  - id: 038b471e2efde2e8f96b4e0be958d3e5a1ff1d05
     repository: https://github.com/FasterXML/jackson-databind
 artifacts:
 - id: pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.5.1

--- a/statements/CVE-2018-8008/statement.yaml
+++ b/statements/CVE-2018-8008/statement.yaml
@@ -4,17 +4,17 @@ notes:
 fixes:
 - id: 1.0.x
   commits:
-  - id: 0fc6b522487c061f89e8cdacf09f722d3f20589
+  - id: 0fc6b522487c061f89e8cdacf09f722d3f20589a
     repository: https://github.com/apache/storm
 - id: master
   commits:
-  - id: 1117a37b01a1058897a34e11ff5156e465efb69
+  - id: 1117a37b01a1058897a34e11ff5156e465efb692
     repository: https://github.com/apache/storm
 - id: "1.2"
   commits:
-  - id: efad4cca2d7d461f5f8c08a0d7b51fabeb82d0a
+  - id: efad4cca2d7d461f5f8c08a0d7b51fabeb82d0af
     repository: https://github.com/apache/storm
 - id: "1.1"
   commits:
-  - id: f61e5daf299d6c37c7ad65744d02556c94a16a4
+  - id: f61e5daf299d6c37c7ad65744d02556c94a16a4b
     repository: https://github.com/apache/storm

--- a/statements/CVE-2018-8009/statement.yaml
+++ b/statements/CVE-2018-8009/statement.yaml
@@ -4,43 +4,43 @@ notes:
 fixes:
 - id: "2"
   commits:
-  - id: 6d7d192e4799b51931e55217e02baec14d49607
+  - id: 6d7d192e4799b51931e55217e02baec14d49607b
     repository: https://github.com/apache/hadoop
-  - id: cedc28d4ab2a27ba47e15ab2711218d96ec88d2
+  - id: cedc28d4ab2a27ba47e15ab2711218d96ec88d23
     repository: https://github.com/apache/hadoop
 - id: trunk
   commits:
-  - id: 745f203e577bacb35b042206db94615141fa5e6
+  - id: 745f203e577bacb35b042206db94615141fa5e6f
     repository: https://github.com/apache/hadoop
-  - id: e3236a9680709de7a95ffbc11b20e1bdc95a860
+  - id: e3236a9680709de7a95ffbc11b20e1bdc95a8605
     repository: https://github.com/apache/hadoop
 - id: "3.1"
   commits:
-  - id: 11a425d11a329010d0ff8255ecbcd1eb51b642e
+  - id: 11a425d11a329010d0ff8255ecbcd1eb51b642e3
     repository: https://github.com/apache/hadoop
-  - id: fc4c20fc3469674cb584a4fb98bac7e3c2277c9
+  - id: fc4c20fc3469674cb584a4fb98bac7e3c2277c96
     repository: https://github.com/apache/hadoop
 - id: "2.8"
   commits:
-  - id: 12258c7cff8d32710fbd8b9088a930e3ce27432
+  - id: 12258c7cff8d32710fbd8b9088a930e3ce27432e
     repository: https://github.com/apache/hadoop
 - id: "2.9"
   commits:
-  - id: 1373e3d8ad60e4da721a292912cb69243bfdf47
+  - id: 1373e3d8ad60e4da721a292912cb69243bfdf470
     repository: https://github.com/apache/hadoop
-  - id: 6a4ae6f6eeed1392a4828a5721fa1499f65bdde
+  - id: 6a4ae6f6eeed1392a4828a5721fa1499f65bdde4
     repository: https://github.com/apache/hadoop
 - id: "2.7"
   commits:
-  - id: 45a1c680c276c4501402f7bc4cebcf85a6fbc7f
+  - id: 45a1c680c276c4501402f7bc4cebcf85a6fbc7f5
     repository: https://github.com/apache/hadoop
-  - id: eaa2b8035b584dfcf7c79a33484eb2dffd3fdb1
+  - id: eaa2b8035b584dfcf7c79a33484eb2dffd3fdb11
     repository: https://github.com/apache/hadoop
 - id: "3.0"
   commits:
-  - id: 65e55097da2bb3f2fbdf9ba1946da25fe58bec9
+  - id: 65e55097da2bb3f2fbdf9ba1946da25fe58bec98
     repository: https://github.com/apache/hadoop
-  - id: bd98d4e77cf9f7b2f4b1afb4d5e5bad0f6b2fde
+  - id: bd98d4e77cf9f7b2f4b1afb4d5e5bad0f6b2fde3
     repository: https://github.com/apache/hadoop
 artifacts:
 - id: pkg:maven/org.apache.hadoop/hadoop-common@2.6.4

--- a/statements/CVE-2018-8012/statement.yaml
+++ b/statements/CVE-2018-8012/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 3.5.4
   commits:
-  - id: 5a29daedeb5ac7e9e2af87ce1a7bbfad230d5c8
+  - id: 5a29daedeb5ac7e9e2af87ce1a7bbfad230d5c86
     repository: https://github.com/apache/zookeeper
 - id: master
   commits:
-  - id: 75411ab34a3d53c43c2d508b12314a9788aa417
+  - id: 75411ab34a3d53c43c2d508b12314a9788aa417d
     repository: https://github.com/apache/zookeeper
 - id: 3.4.10
   commits:
-  - id: 8a06bd1ccef382461c7b0a63f2012f4aeac9075
+  - id: 8a06bd1ccef382461c7b0a63f2012f4aeac90753
     repository: https://github.com/apache/zookeeper
 artifacts:
 - id: pkg:maven/org.apache.zookeeper/zookeeper@3.4.8

--- a/statements/CVE-2018-8017/statement.yaml
+++ b/statements/CVE-2018-8017/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: "1.19"
   commits:
-  - id: 62926cae31a02d4f23d21148435804b96c543cc
+  - id: 62926cae31a02d4f23d21148435804b96c543cc7
     repository: https://github.com/apache/tika
 - id: 1.x
   commits:
-  - id: 8a6a9e1344f5b10ebfa1a189dc3c30d0da2b9d4
+  - id: 8a6a9e1344f5b10ebfa1a189dc3c30d0da2b9d4b
     repository: https://github.com/apache/tika
 artifacts:
 - id: pkg:maven/org.apache.tika/tika-parsers@1.19

--- a/statements/CVE-2018-8018/statement.yaml
+++ b/statements/CVE-2018-8018/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: "2.6"
   commits:
-  - id: 82a7b8209fcf56971d12cb10410a38ed632215b
+  - id: 82a7b8209fcf56971d12cb10410a38ed632215b2
     repository: https://github.com/apache/ignite
 - id: master
   commits:
-  - id: bc374f85ca4a5e69572902d2167fe6bedebd40a
+  - id: bc374f85ca4a5e69572902d2167fe6bedebd40a2
     repository: https://github.com/apache/ignite
 artifacts:
 - id: pkg:maven/org.apache.ignite/ignite-core@2.4.0

--- a/statements/CVE-2018-8025/statement.yaml
+++ b/statements/CVE-2018-8025/statement.yaml
@@ -4,21 +4,21 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 0c42acbdf86d08af3003105a26a2201f75f2e2c
+  - id: 0c42acbdf86d08af3003105a26a2201f75f2e2c3
     repository: https://github.com/apache/hbase
 - id: "1.4"
   commits:
-  - id: 30e98b4455f971c9cb3c02ac7b2daeebe4ee6f2
+  - id: 30e98b4455f971c9cb3c02ac7b2daeebe4ee6f2d
     repository: https://github.com/apache/hbase
 - id: "1.2"
   commits:
-  - id: 625d4d002620139f49c8201f95b789b6a715cd4
+  - id: 625d4d002620139f49c8201f95b789b6a715cd41
     repository: https://github.com/apache/hbase
 - id: "2.0"
   commits:
-  - id: 7fe07075b35a816725ba18f6dd43d3fa84e08f9
+  - id: 7fe07075b35a816725ba18f6dd43d3fa84e08f93
     repository: https://github.com/apache/hbase
 - id: "1.3"
   commits:
-  - id: bf25c1cb7221178388baaa58f0b16a408e151a6
+  - id: bf25c1cb7221178388baaa58f0b16a408e151a69
     repository: https://github.com/apache/hbase

--- a/statements/CVE-2018-8026/statement.yaml
+++ b/statements/CVE-2018-8026/statement.yaml
@@ -4,23 +4,23 @@ notes:
 fixes:
 - id: "7.4"
   commits:
-  - id: 3aa6086ed99fa7158d423dc7c33dae6da466b09
+  - id: 3aa6086ed99fa7158d423dc7c33dae6da466b093
     repository: https://github.com/apache/lucene-solr
 - id: 6.6.5
   commits:
-  - id: d1baf6ba593561f39e2da0a71a8440797005b55
+  - id: d1baf6ba593561f39e2da0a71a8440797005b55c
     repository: https://github.com/apache/lucene-solr
 - id: master
   commits:
-  - id: e21d4937e0637c7b7949ac463f331da9a42c07f
+  - id: e21d4937e0637c7b7949ac463f331da9a42c07f9
     repository: https://github.com/apache/lucene-solr
 - id: 7.x
   commits:
-  - id: e5407c5a9710247e5f728aae36224a245a51f0b
+  - id: e5407c5a9710247e5f728aae36224a245a51f0b1
     repository: https://github.com/apache/lucene-solr
 - id: 6.x
   commits:
-  - id: 1880d4824e6c5f98170b9a00aad1d437ee2aa12
+  - id: 1880d4824e6c5f98170b9a00aad1d437ee2aa12b
     repository: https://github.com/apache/lucene-solr
 artifacts:
 - id: pkg:maven/org.apache.solr/solr-core@7.1.0

--- a/statements/CVE-2018-8027/statement.yaml
+++ b/statements/CVE-2018-8027/statement.yaml
@@ -4,37 +4,37 @@ notes:
 fixes:
 - id: 2.17.6
   commits:
-  - id: 22c355bb4ffb500405499d189db30932ca5aac9
+  - id: 22c355bb4ffb500405499d189db30932ca5aac92
     repository: https://github.com/apache/camel
-  - id: 2c6964ae94d8f9a9c9a32e5ae5a0b794e8b8d3b
+  - id: 2c6964ae94d8f9a9c9a32e5ae5a0b794e8b8d3be
     repository: https://github.com/apache/camel
-  - id: 99cbcd78b7e64083fae1d9552ead7425a90994b
+  - id: 99cbcd78b7e64083fae1d9552ead7425a90994bd
     repository: https://github.com/apache/camel
 - id: "2.21"
   commits:
-  - id: 24eefa559fe6b310629d2bf00663d2679ec81b9
+  - id: 24eefa559fe6b310629d2bf00663d2679ec81b96
     repository: https://github.com/apache/camel
-  - id: 9c6a8f61de40c20f28240fbb2af4cb425793d41
+  - id: 9c6a8f61de40c20f28240fbb2af4cb425793d41e
     repository: https://github.com/apache/camel
 - id: "2.22"
   commits:
-  - id: 2e8f21dec883b083ddcdddd802847b4c378a61a
+  - id: 2e8f21dec883b083ddcdddd802847b4c378a61a2
     repository: https://github.com/apache/camel
-  - id: 8467d644813a62f3a836c0c7dee8cf5a41de3c0
+  - id: 8467d644813a62f3a836c0c7dee8cf5a41de3c07
     repository: https://github.com/apache/camel
 - id: "2.20"
   commits:
-  - id: 3fe03e361725b66c1c3eaa40bb11577fb3dc17b
+  - id: 3fe03e361725b66c1c3eaa40bb11577fb3dc17b3
     repository: https://github.com/apache/camel
-  - id: 8afc5d1757795fde715902067360af5d90f046d
+  - id: 8afc5d1757795fde715902067360af5d90f046da
     repository: https://github.com/apache/camel
 - id: 2.18.3
   commits:
-  - id: 87c92b7b38890c217bc76f2c55036e6a5cca9a0
+  - id: 87c92b7b38890c217bc76f2c55036e6a5cca9a07
     repository: https://github.com/apache/camel
-  - id: 9f7376abbff7434794f2c7c2909e02bac232fb5
+  - id: 9f7376abbff7434794f2c7c2909e02bac232fb5b
     repository: https://github.com/apache/camel
-  - id: ec3d0db81ba061b27e934d5ff56e9baca0049eb
+  - id: ec3d0db81ba061b27e934d5ff56e9baca0049ebf
     repository: https://github.com/apache/camel
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-core@2.13.3

--- a/statements/CVE-2018-8041/statement.yaml
+++ b/statements/CVE-2018-8041/statement.yaml
@@ -4,17 +4,17 @@ notes:
 fixes:
 - id: master
   commits:
-  - id: 4580e4d6c65cfd544c1791c824b5819477c583c
+  - id: 4580e4d6c65cfd544c1791c824b5819477c583cc
     repository: https://github.com/apache/camel
 - id: 2.21.2
   commits:
-  - id: 4f401c09d22c45c94fa97746dc31905e06b19e3
+  - id: 4f401c09d22c45c94fa97746dc31905e06b19e3b
     repository: https://github.com/apache/camel
 - id: 2.20.4
   commits:
-  - id: 63c7c080de4d18f9ceb25843508710df2c2c6d4
+  - id: 63c7c080de4d18f9ceb25843508710df2c2c6d40
     repository: https://github.com/apache/camel
 - id: 2.22.1
   commits:
-  - id: a0d25d9582c6ee85e9567fa39413df0b4f02ef7
+  - id: a0d25d9582c6ee85e9567fa39413df0b4f02ef7b
     repository: https://github.com/apache/camel

--- a/statements/CVE-2019-0191/statement.yaml
+++ b/statements/CVE-2019-0191/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: "4.1"
   commits:
-  - id: e36a7a66fa08eb5eb253b2b0cec262ffbdef072
+  - id: e36a7a66fa08eb5eb253b2b0cec262ffbdef0721
     repository: https://github.com/apache/karaf
 - id: "4.2"
   commits:
-  - id: fef9a618f11a670dc040d903a4b0f9bbc9f3e9c
+  - id: fef9a618f11a670dc040d903a4b0f9bbc9f3e9c3
     repository: https://github.com/apache/karaf

--- a/statements/CVE-2019-0194/statement.yaml
+++ b/statements/CVE-2019-0194/statement.yaml
@@ -4,33 +4,33 @@ notes:
 fixes:
 - id: 2.23.2
   commits:
-  - id: 2d399aa6062fccd6af496bd776314d1944f7090
+  - id: 2d399aa6062fccd6af496bd776314d1944f7090f
     repository: https://github.com/apache/camel
-  - id: 53185f0b221b899aacb3c379647a866a8f408a8
+  - id: 53185f0b221b899aacb3c379647a866a8f408a87
     repository: https://github.com/apache/camel
 - id: 2.21.5
   commits:
-  - id: 5e1d70c6957703cdebbfe5d796462e5a89c8bc2
+  - id: 5e1d70c6957703cdebbfe5d796462e5a89c8bc26
     repository: https://github.com/apache/camel
-  - id: f337a98e86ef18611b14570e6780053fe3ddcc0
+  - id: f337a98e86ef18611b14570e6780053fe3ddcc02
     repository: https://github.com/apache/camel
 - id: 2.16.0
   commits:
-  - id: 68f2de31b7752bd49b7898d7098b3bfe8e0d0bd
+  - id: 68f2de31b7752bd49b7898d7098b3bfe8e0d0bdb
     repository: https://github.com/apache/camel
-  - id: a8a2b8c0a37e348981a4cf41fd2b329b6079f40
+  - id: a8a2b8c0a37e348981a4cf41fd2b329b6079f40b
     repository: https://github.com/apache/camel
 - id: 3.0.0
   commits:
-  - id: 05ff65d5cebf1fa5172c59dd16359ed583c099c
+  - id: 05ff65d5cebf1fa5172c59dd16359ed583c099ca
     repository: https://github.com/apache/camel
-  - id: 5b64969d37cf2906efd4623cfd473041ce5132f
+  - id: 5b64969d37cf2906efd4623cfd473041ce5132fd
     repository: https://github.com/apache/camel
 - id: 2.23.1
   commits:
-  - id: 15a1f10fb532bdcba184cda17be602a2358bd5e
+  - id: 15a1f10fb532bdcba184cda17be602a2358bd5e8
     repository: https://github.com/apache/camel
-  - id: e030f6665db037a2f73f30b9125fb770f29a7bd
+  - id: e030f6665db037a2f73f30b9125fb770f29a7bd4
     repository: https://github.com/apache/camel
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-file@3.0.0-M4

--- a/statements/CVE-2019-0199/statement.yaml
+++ b/statements/CVE-2019-0199/statement.yaml
@@ -4,35 +4,35 @@ notes:
 fixes:
 - id: 8.5.x
   commits:
-  - id: 1f80116084f7db68a34258e7702d47327d53516
+  - id: 1f80116084f7db68a34258e7702d47327d53516c
     repository: https://github.com/apache/tomcat
-  - id: 2c5939e1db671c5087fc32c2472b453e3b13d78
+  - id: 2c5939e1db671c5087fc32c2472b453e3b13d789
     repository: https://github.com/apache/tomcat
-  - id: 65f4b6d18159b0d3368c42d68763769dfbcb385
+  - id: 65f4b6d18159b0d3368c42d68763769dfbcb3851
     repository: https://github.com/apache/tomcat
-  - id: 69c57c8c5f7336b3ffefcc88fd49b51b8f5f4bf
+  - id: 69c57c8c5f7336b3ffefcc88fd49b51b8f5f4bf8
     repository: https://github.com/apache/tomcat
-  - id: 738eef58a30f6d3ec9c9de707ba6491904fa579
+  - id: 738eef58a30f6d3ec9c9de707ba6491904fa5796
     repository: https://github.com/apache/tomcat
-  - id: cd9b2fbc54243b77d4dd93306298ecf0804e682
+  - id: cd9b2fbc54243b77d4dd93306298ecf0804e6820
     repository: https://github.com/apache/tomcat
-  - id: 19bebdecbd82a3fce3187a14e0ac417ce8d9b60
+  - id: 19bebdecbd82a3fce3187a14e0ac417ce8d9b604
     repository: https://github.com/apache/tomcat
 - id: 9.0.x
   commits:
-  - id: b711cf5b8841e5d239717850d1d6d3cad2382a6
+  - id: b711cf5b8841e5d239717850d1d6d3cad2382a6b
     repository: https://github.com/apache/tomcat
-  - id: c16d9d810a1f64cd768ff33058936cf8907e311
+  - id: c16d9d810a1f64cd768ff33058936cf8907e3117
     repository: https://github.com/apache/tomcat
-  - id: c38033338a5d145630275ff91fef04c7dfd7807
+  - id: c38033338a5d145630275ff91fef04c7dfd78073
     repository: https://github.com/apache/tomcat
-  - id: f9d8c2591f86090e5141f73833407f7ebdffef2
+  - id: f9d8c2591f86090e5141f73833407f7ebdffef26
     repository: https://github.com/apache/tomcat
-  - id: 2207733b82d85e354fa1a6fd114dae665816fdf
+  - id: 2207733b82d85e354fa1a6fd114dae665816fdf9
     repository: https://github.com/apache/tomcat
-  - id: 4424600f427ba94058113537023c77953fcfb54
+  - id: 4424600f427ba94058113537023c77953fcfb544
     repository: https://github.com/apache/tomcat
-  - id: 96f351883cdc6a20919d4b98964f101d67e92aa
+  - id: 96f351883cdc6a20919d4b98964f101d67e92aa6
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.41

--- a/statements/CVE-2019-0201/statement.yaml
+++ b/statements/CVE-2019-0201/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 3.5.5
   commits:
-  - id: 17c6b264f4e79ddb6e9d27b968d48456024d18c
+  - id: 17c6b264f4e79ddb6e9d27b968d48456024d18cc
     repository: https://github.com/apache/zookeeper
 - id: 3.4.14
   commits:
-  - id: 5ff19e3672987bdde2843a3f031e2bf0010e35f
+  - id: 5ff19e3672987bdde2843a3f031e2bf0010e35f1
     repository: https://github.com/apache/zookeeper
 - id: master
   commits:
-  - id: af741cb319d4760cfab1cd3b560635adacd8dec
+  - id: af741cb319d4760cfab1cd3b560635adacd8deca
     repository: https://github.com/apache/zookeeper
 artifacts:
 - id: pkg:maven/org.apache.zookeeper/zookeeper@3.5.7

--- a/statements/CVE-2019-0212/statement.yaml
+++ b/statements/CVE-2019-0212/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: 2.0.x
   commits:
-  - id: 18f07455ea9be4166dabb9b590f5a037374830b
+  - id: 18f07455ea9be4166dabb9b590f5a037374830b6
     repository: https://github.com/apache/hbase
 - id: 2.1.x
   commits:
-  - id: 7206ef6427d12785b797797a00153b5437e21cb
+  - id: 7206ef6427d12785b797797a00153b5437e21cb1
     repository: https://github.com/apache/hbase

--- a/statements/CVE-2019-0221/statement.yaml
+++ b/statements/CVE-2019-0221/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 7.x
   commits:
-  - id: 44ec74
+  - id: 44ec74c44dcd05cd7e90967c04d40b51440ecd7e
     repository: https://github.com/apache/tomcat
 - id: 8.x
   commits:
-  - id: 4fcdf7
+  - id: 4fcdf706f3ecf35912a600242f89637f5acb32da
     repository: https://github.com/apache/tomcat
 - id: 9.x
   commits:
-  - id: 15fcd1
+  - id: 15fcd166ea2c1bb79e8541b8e1a43da9c452ceea
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.41

--- a/statements/CVE-2019-0231/statement.yaml
+++ b/statements/CVE-2019-0231/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.0.21
   commits:
-  - id: 294b8ce638df6e237e819537b333e02853bb612
+  - id: 294b8ce638df6e237e819537b333e02853bb612c
     repository: https://github.com/apache/mina
 - id: 2.1.1
   commits:
-  - id: 73e881ad935e5aa6080b90585ac8dc8ddfc377e
+  - id: 73e881ad935e5aa6080b90585ac8dc8ddfc377e1
     repository: https://github.com/apache/mina
 artifacts:
 - id: pkg:maven/org.apache.mina/mina-core@2.0.2

--- a/statements/CVE-2019-0232/statement.yaml
+++ b/statements/CVE-2019-0232/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 8.5.x
   commits:
-  - id: 5bc4e6
+  - id: 5bc4e6d7b1c22dc1bf99f475b7e70594ebdd83b9
     repository: https://github.com/apache/tomcat
 - id: 7.0.x
   commits:
-  - id: 7f0221
+  - id: 7f0221b904956359f2d739aa3a2b53f8c12ed8c7
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat/tomcat-catalina@9.0.31

--- a/statements/CVE-2019-10072/statement.yaml
+++ b/statements/CVE-2019-10072/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 8.5.41
   commits:
-  - id: 0bcd69
+  - id: 0bcd69c9dd8ae0ff424f2cd46de51583510b7f35
     repository: https://github.com/apache/tomcat
-  - id: 8d14c6
+  - id: 8d14c6f21d29768a39be4b6b9517060dc6606758
     repository: https://github.com/apache/tomcat
 - id: 9.0.20
   commits:
-  - id: 7f748e
+  - id: 7f748eb6bfaba5207c89dbd7d5adf50fae847145
     repository: https://github.com/apache/tomcat
-  - id: ada725
+  - id: ada725a50a60867af3422c8e612aecaeea856a9a
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat/tomcat-coyote@8.5.50

--- a/statements/CVE-2019-10156/statement.yaml
+++ b/statements/CVE-2019-10156/statement.yaml
@@ -15,7 +15,7 @@ fixes:
     repository: https://github.com/bcoca/ansible
 - id: unsafer26
   commits:
-  - id: 2c8d5ca68a2d728dc2c0f681ec630186bd27438
+  - id: 2c8d5ca68a2d728dc2c0f681ec630186bd274381
     repository: https://github.com/bcoca/ansible
 artifacts:
 - id: pkg:maven/ansible/ansible@2.8.2

--- a/statements/CVE-2019-11236/statement.yaml
+++ b/statements/CVE-2019-11236/statement.yaml
@@ -11,9 +11,9 @@ fixes:
     repository: https://github.com/urllib3/urllib3
 - id: 1.24.x
   commits:
-  - id: 9b76785331243689a9d52cef3db05ef7462cb02
+  - id: 9b76785331243689a9d52cef3db05ef7462cb02d
     repository: https://github.com/urllib3/urllib3
-  - id: efddd7e7bad26188c3b692d1090cba768afa916
+  - id: efddd7e7bad26188c3b692d1090cba768afa9162
     repository: https://github.com/urllib3/urllib3
 artifacts:
 - id: pkg:maven/urllib3/urllib3@1.22

--- a/statements/CVE-2019-12399/statement.yaml
+++ b/statements/CVE-2019-12399/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
 - id: 2.2
   commits:
-  - id: 5d2a6dc531150423a40f77783a4a09e1b0f9017
+  - id: 5d2a6dc531150423a40f77783a4a09e1b0f90178
     repository: https://github.com/apache/kafka
 - id: 2.0
   commits:
-  - id: 921937ba3b897b9a16b806bab2111362064ff83
+  - id: 921937ba3b897b9a16b806bab2111362064ff83c
     repository: https://github.com/apache/kafka
 - id: 2.3
   commits:
-  - id: b85707c0fdb4c11448cdb5a1938e0488ddc9110
+  - id: b85707c0fdb4c11448cdb5a1938e0488ddc91102
     repository: https://github.com/apache/kafka
 - id: 2.1
   commits:
-  - id: e20bc24909c22875d17c4a90d1d0c9c6608001b
+  - id: e20bc24909c22875d17c4a90d1d0c9c6608001b6
     repository: https://github.com/apache/kafka
 artifacts:
 - id: pkg:maven/org.apache.kafka/connect-runtime@2.0.1

--- a/statements/CVE-2019-12406/statement.yaml
+++ b/statements/CVE-2019-12406/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 6c3990144b56097502aa9f3ec9c06f303110902
+  - id: 6c3990144b56097502aa9f3ec9c06f3031109022
     repository: https://github.com/apache/cxf
 - id: 3.3.x-fixes
   commits:
-  - id: fd85803a73ad46f36816bcb55ed1c4f4b4c4312
+  - id: fd85803a73ad46f36816bcb55ed1c4f4b4c4312d
     repository: https://github.com/apache/cxf
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-bundle@2.7.9

--- a/statements/CVE-2019-12418/statement.yaml
+++ b/statements/CVE-2019-12418/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 1fc9f5
+  - id: 1fc9f589dbdd8295cf313b2667ab041c425f99c3
     repository: https://github.com/apache/tomcat
-  - id: a91d7d
+  - id: a91d7db4047d372b2f12999d3cf2bc3254c20d00
     repository: https://github.com/apache/tomcat
-  - id: bef3f4
+  - id: bef3f40400243348d12f4abfe9b413f43897c02b
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat/tomcat-catalina-jmx-remote@7.0.82

--- a/statements/CVE-2019-12419/statement.yaml
+++ b/statements/CVE-2019-12419/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 3.3.x-fixes
   commits:
-  - id: 6bf89927d3e07197d49453b00d673eadce696cf
+  - id: 6bf89927d3e07197d49453b00d673eadce696cf9
     repository: https://github.com/apache/cxf
 - id: 3.2.x-fixes
   commits:
-  - id: db6069667708a59c75a785f310d4a2df3698122
+  - id: db6069667708a59c75a785f310d4a2df3698122c
     repository: https://github.com/apache/cxf
 - id: DEFAULT_BRANCH
   commits:
-  - id: 337609d81a9f53e7680cb79d9ab733a79f4cd76
+  - id: 337609d81a9f53e7680cb79d9ab733a79f4cd769
     repository: https://github.com/apache/cxf
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-rt-rs-security-oauth2@3.2.10

--- a/statements/CVE-2019-12423/statement.yaml
+++ b/statements/CVE-2019-12423/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 3.3.x-fixes
   commits:
-  - id: 2de7e14eb95626fffef6f61365186de9a1c9de3
+  - id: 2de7e14eb95626fffef6f61365186de9a1c9de3d
     repository: https://github.com/apache/cxf
 - id: 3.2.x-fixes
   commits:
-  - id: 8b40fdba289c62f4defae51c1f76860f0159c44
+  - id: 8b40fdba289c62f4defae51c1f76860f0159c441
     repository: https://github.com/apache/cxf
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-rt-rs-security-jose@3.2.12

--- a/statements/CVE-2019-16869/statement.yaml
+++ b/statements/CVE-2019-16869/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 017a9658c97ff1a1355c31a6a1f8bd1ea6f21c8
+  - id: 017a9658c97ff1a1355c31a6a1f8bd1ea6f21c8d
     repository: https://github.com/netty/netty
 - id: 4.1
   commits:
-  - id: 39cafcb05c99f2aa9fce7e6597664c9ed6a63a9
+  - id: 39cafcb05c99f2aa9fce7e6597664c9ed6a63a95
     repository: https://github.com/netty/netty
 artifacts:
 - id: pkg:maven/io.netty/netty-all@4.0.23.Final

--- a/statements/CVE-2019-17563/statement.yaml
+++ b/statements/CVE-2019-17563/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: e19a20
+  - id: e19a202ee43b6e2a538be5515ae0ab32d8ef112c
     repository: https://github.com/apache/tomcat
-  - id: 1ecba1
+  - id: 1ecba14e690cf5f3f143eef6ae7037a6d3c16652
     repository: https://github.com/apache/tomcat
-  - id: ab72a1
+  - id: ab72a106fe5d992abddda954e30849d7cf8cc583
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.41

--- a/statements/CVE-2019-17569/statement.yaml
+++ b/statements/CVE-2019-17569/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 060ecc
+  - id: 060ecc5eb839208687b7fcc9e35287ac8eb46998
     repository: https://github.com/apache/tomcat
-  - id: 959f1d
+  - id: 959f1dfd767bf3cb64776b44f7395d1d8d8f7ab3
     repository: https://github.com/apache/tomcat
-  - id: b191a0
+  - id: b191a0d9cf06f4e04257c221bfe41d2b108a9cc8
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M7

--- a/statements/CVE-2019-17573/statement.yaml
+++ b/statements/CVE-2019-17573/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 3.3.x-fixes
   commits:
-  - id: a02e96ba1095596bef481919f16a90c5e80a92c
+  - id: a02e96ba1095596bef481919f16a90c5e80a92c8
     repository: https://github.com/apache/cxf
 - id: 3.2.x-fixes
   commits:
-  - id: ffee603ae648c25f6ce5aa01b92c3aa57ebd568
+  - id: ffee603ae648c25f6ce5aa01b92c3aa57ebd5681
     repository: https://github.com/apache/cxf
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-bundle@2.7.9

--- a/statements/CVE-2019-3773/statement.yaml
+++ b/statements/CVE-2019-3773/statement.yaml
@@ -8,7 +8,7 @@ fixes:
     repository: https://github.com/spring-projects/spring-ws
 - id: 2.x
   commits:
-  - id: d1c87ab466df43f4a615a6ecee6f0d7039cf4e4
+  - id: d1c87ab466df43f4a615a6ecee6f0d7039cf4e4e
     repository: https://github.com/spring-projects/spring-ws
 artifacts:
 - id: pkg:maven/org.springframework.ws/spring-xml@3.0.4.RELEASE

--- a/statements/CVE-2019-3778/statement.yaml
+++ b/statements/CVE-2019-3778/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
 - id: 2.0.17
   commits:
-  - id: da157a89402eeb2d5d071db3558c3b417bfc3ed
+  - id: da157a89402eeb2d5d071db3558c3b417bfc3ed0
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.1.4
   commits:
-  - id: 16d39adbc04bb0cdf217226803d05d6956595d8
+  - id: 16d39adbc04bb0cdf217226803d05d6956595d85
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.3.5
   commits:
-  - id: 97e0b4ab282acbed3588e05be03d5a0c4dbf336
+  - id: 97e0b4ab282acbed3588e05be03d5a0c4dbf3367
     repository: https://github.com/spring-projects/spring-security-oauth
 - id: 2.2.4
   commits:
-  - id: b436f745af2be24924ecc68524fd2582bcdfdc3
+  - id: b436f745af2be24924ecc68524fd2582bcdfdc38
     repository: https://github.com/spring-projects/spring-security-oauth
 artifacts:
 - id: pkg:maven/org.springframework.security.oauth/spring-security-oauth2@2.0.15.RELEASE

--- a/statements/CVE-2019-3795/statement.yaml
+++ b/statements/CVE-2019-3795/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
 - id: 5.0.x
   commits:
-  - id: 1304c958bf9c38940082f3ad1558d413ed82f2b
+  - id: 1304c958bf9c38940082f3ad1558d413ed82f2b6
     repository: https://github.com/spring-projects/spring-security
 - id: 5.1.x
   commits:
-  - id: 3ddcbde466c16646a3a858baa57aafd8e65f6d5
+  - id: 3ddcbde466c16646a3a858baa57aafd8e65f6d52
     repository: https://github.com/spring-projects/spring-security
 - id: 4.2.x
   commits:
-  - id: 6f02f690ac65ccf99d8df47ac3d730a68f87c56
+  - id: 6f02f690ac65ccf99d8df47ac3d730a68f87c569
     repository: https://github.com/spring-projects/spring-security
 - id: master
   commits:
-  - id: 9c1eac79e2abb50f7b01e77c2418566f2a30532
+  - id: 9c1eac79e2abb50f7b01e77c2418566f2a30532f
     repository: https://github.com/spring-projects/spring-security
 artifacts:
 - id: pkg:maven/org.springframework.security/spring-security-core@5.0.8.RELEASE

--- a/statements/CVE-2019-3797/statement.yaml
+++ b/statements/CVE-2019-3797/statement.yaml
@@ -4,33 +4,33 @@ notes:
 fixes:
 - id: 2.1.x
   commits:
-  - id: 9b16fef6e9a1c8f4352cb979df8ef4a9336d655
+  - id: 9b16fef6e9a1c8f4352cb979df8ef4a9336d6552
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: ee39e8863bb43b63e34fe9ac6ec9b864cd8afca
+  - id: ee39e8863bb43b63e34fe9ac6ec9b864cd8afca9
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: 16661f7e7e28f8ea8585a0402bd91eb6721ce55
+  - id: 16661f7e7e28f8ea8585a0402bd91eb6721ce55b
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: 417202db8e1714bdca1bd57879634866934c6f5
+  - id: 417202db8e1714bdca1bd57879634866934c6f54
     repository: https://github.com/spring-projects/spring-data-jpa
 - id: 1.11.x
   commits:
-  - id: 271a2814157c5de78345effdbe2a21c740880cd
+  - id: 271a2814157c5de78345effdbe2a21c740880cdb
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: 89b18d573394c84012c58c892e9a3844fb8c7b4
+  - id: 89b18d573394c84012c58c892e9a3844fb8c7b40
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: 8a5743c74b7ab1daf7cb428fee0d9b3f03fb914
+  - id: 8a5743c74b7ab1daf7cb428fee0d9b3f03fb9146
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: c47a5d09a1123ca8e77f832f8335e227b820b3f
+  - id: c47a5d09a1123ca8e77f832f8335e227b820b3fc
     repository: https://github.com/spring-projects/spring-data-jpa
 - id: 2.0.x
   commits:
-  - id: 4d4e6d418fe3bca14c7cff1c7161e3794026f96
+  - id: 4d4e6d418fe3bca14c7cff1c7161e3794026f960
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: 899b8b0db3d40603488ad50f116ab9e68021ba3
+  - id: 899b8b0db3d40603488ad50f116ab9e68021ba35
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: b6060be66b6cbf447c0c62e5b80caa565e10f38
+  - id: b6060be66b6cbf447c0c62e5b80caa565e10f383
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: ee03f9b4a5facaee1b9d25313862e1d043f5a5d
+  - id: ee03f9b4a5facaee1b9d25313862e1d043f5a5dc
     repository: https://github.com/spring-projects/spring-data-jpa
 artifacts:
 - id: pkg:maven/org.springframework.data/spring-data-jpa@1.9.5.RELEASE

--- a/statements/CVE-2019-3802/statement.yaml
+++ b/statements/CVE-2019-3802/statement.yaml
@@ -4,21 +4,21 @@ notes:
 fixes:
 - id: 2.1.8
   commits:
-  - id: c4baa0df0cbb76ae1c56795c40f3e2715e89f5e
+  - id: c4baa0df0cbb76ae1c56795c40f3e2715e89f5ec
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: d5f88165069fb53c3d034559cc2873e9a9a9563
+  - id: d5f88165069fb53c3d034559cc2873e9a9a95633
     repository: https://github.com/spring-projects/spring-data-jpa
 - id: 2.2.0
   commits:
-  - id: 075b4bad6fbcf85237e34568b1dde5c3c896738
+  - id: 075b4bad6fbcf85237e34568b1dde5c3c8967386
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: ac02bc062b224d3983c7fc6806e74488acf7a53
+  - id: ac02bc062b224d3983c7fc6806e74488acf7a53e
     repository: https://github.com/spring-projects/spring-data-jpa
 - id: 1.1.x
   commits:
-  - id: 2ef1b156a7ae0aea0e78b48fa97ead78989c63d
+  - id: 2ef1b156a7ae0aea0e78b48fa97ead78989c63d7
     repository: https://github.com/spring-projects/spring-data-jpa
-  - id: 33027dc370f418981f41f8fdfebc7173155960a
+  - id: 33027dc370f418981f41f8fdfebc7173155960a1
     repository: https://github.com/spring-projects/spring-data-jpa
 artifacts:
 - id: pkg:maven/org.springframework.data/spring-data-jpa@1.9.5.RELEASE

--- a/statements/CVE-2019-7619/statement.yaml
+++ b/statements/CVE-2019-7619/statement.yaml
@@ -4,5 +4,5 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 9964d89dd5d67cf72a85eb48d76347f09bd875f
+  - id: 9964d89dd5d67cf72a85eb48d76347f09bd875f5
     repository: https://github.com/elastic/elasticsearch

--- a/statements/CVE-2020-10683/statement.yaml
+++ b/statements/CVE-2020-10683/statement.yaml
@@ -4,7 +4,7 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: a822852
+  - id: a8228522a99a02146106672a34c104adbda5c658
     repository: https://github.com/dom4j/dom4j
 artifacts:
 - id: pkg:maven/org.dom4j/dom4j@2.1.1

--- a/statements/CVE-2020-11002/statement.yaml
+++ b/statements/CVE-2020-11002/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: release/1.3.x
   commits:
-  - id: 74e211514db951a67b0e9ff75b0102704d4b204
+  - id: 74e211514db951a67b0e9ff75b0102704d4b2049
     repository: https://github.com/dropwizard/dropwizard
 - id: release/4.0.x
   commits:
-  - id: d5a512f7abf965275f2a6b913ac4fe778e42424
+  - id: d5a512f7abf965275f2a6b913ac4fe778e424242
     repository: https://github.com/dropwizard/dropwizard
 artifacts:
 - id: pkg:maven/io.dropwizard/dropwizard-validation@1.3.0

--- a/statements/CVE-2020-11057/statement.yaml
+++ b/statements/CVE-2020-11057/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: xwiki-platform-11.10.13
   commits:
-  - id: 6d0c3283264cb03c649425b1ef26b007296c4b5
+  - id: 6d0c3283264cb03c649425b1ef26b007296c4b5b
     repository: https://github.com/xwiki/xwiki-platform
 - id: DEFAULT_BRANCH
   commits:
-  - id: 86db078bf1ae3eb49ba5308f55bf3f9a3864e91
+  - id: 86db078bf1ae3eb49ba5308f55bf3f9a3864e916
     repository: https://github.com/xwiki/xwiki-platform
 - id: xwiki-platform-11.3.7
   commits:
-  - id: dc0fa65fa1c55360dd428106ded5934e7caa59b
+  - id: dc0fa65fa1c55360dd428106ded5934e7caa59b1
     repository: https://github.com/xwiki/xwiki-platform

--- a/statements/CVE-2020-11969/statement.yaml
+++ b/statements/CVE-2020-11969/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 17168ad95e35f1758e16364c2398dea10a4034d
+  - id: 17168ad95e35f1758e16364c2398dea10a4034d8
     repository: https://github.com/apache/tomee
 - id: tomee-7.1.x
   commits:
-  - id: 5db25b2850b7bd29d3311c623c7ee2ed5cbb574
+  - id: 5db25b2850b7bd29d3311c623c7ee2ed5cbb5749
     repository: https://github.com/apache/tomee
 - id: tomee-7.0.x
   commits:
-  - id: 6e4c385b9a675c853a539c6b4a0b4d8d9be190c
+  - id: 6e4c385b9a675c853a539c6b4a0b4d8d9be190c9
     repository: https://github.com/apache/tomee
 artifacts:
 - id: pkg:maven/org.apache.tomee/openejb-core@8.0.2

--- a/statements/CVE-2020-11972/statement.yaml
+++ b/statements/CVE-2020-11972/statement.yaml
@@ -4,19 +4,19 @@ notes:
 fixes:
 - id: 3.0.x
   commits:
-  - id: 26f7d74755c436513719147f6bafb6f06c655a9
+  - id: 26f7d74755c436513719147f6bafb6f06c655a97
     repository: https://github.com/apache/camel
 - id: DEFAULT_BRANCH
   commits:
-  - id: 7c8a2785b11e705cb5445fde1cebd3eff3d53b1
+  - id: 7c8a2785b11e705cb5445fde1cebd3eff3d53b1c
     repository: https://github.com/apache/camel
 - id: camel-2.25.x
   commits:
-  - id: 94b2c15247c83f233e4dd7870a526113ead9476
+  - id: 94b2c15247c83f233e4dd7870a526113ead9476c
     repository: https://github.com/apache/camel
 - id: 3.1.x
   commits:
-  - id: c7d6a6bfd8d9bf2ee17a7d40897b1ce4574f410
+  - id: c7d6a6bfd8d9bf2ee17a7d40897b1ce4574f4103
     repository: https://github.com/apache/camel
 artifacts:
 - id: pkg:maven/org.apache.camel/camel-rabbitmq@2.23.2

--- a/statements/CVE-2020-11975/statement.yaml
+++ b/statements/CVE-2020-11975/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: unomi-1.x
   commits:
-  - id: 823386ab117d231df15eab4cb4b7a98f8af546c
+  - id: 823386ab117d231df15eab4cb4b7a98f8af546ca
     repository: https://github.com/apache/unomi
 - id: unomi-1.4.x
   commits:
-  - id: 3d15022e4b52a2fcc0912ef6c259c3905d4f374
+  - id: 3d15022e4b52a2fcc0912ef6c259c3905d4f374a
     repository: https://github.com/apache/unomi
 - id: DEFAULT_BRANCH
   commits:
-  - id: 789ae8e820c507866b9c91590feebffa4e996f5
+  - id: 789ae8e820c507866b9c91590feebffa4e996f5e
     repository: https://github.com/apache/unomi

--- a/statements/CVE-2020-11980/statement.yaml
+++ b/statements/CVE-2020-11980/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 3e4c4bed2d08e81ca5961ab5fcadab23470db1c
+  - id: 3e4c4bed2d08e81ca5961ab5fcadab23470db1c9
     repository: https://github.com/apache/karaf
 - id: karaf-4.2.x
   commits:
-  - id: 2ccfba48bdfac6c2cd09c8f058641da0011e4c7
+  - id: 2ccfba48bdfac6c2cd09c8f058641da0011e4c7e
     repository: https://github.com/apache/karaf

--- a/statements/CVE-2020-11996/statement.yaml
+++ b/statements/CVE-2020-11996/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 9434a44d3449d620b1be70206819f8275b4a750
+  - id: 9434a44d3449d620b1be70206819f8275b4a7509
     repository: https://github.com/apache/tomcat
-  - id: 9a0231683a77e2957cea0fdee88b193b30b0c97
+  - id: 9a0231683a77e2957cea0fdee88b193b30b0c976
     repository: https://github.com/apache/tomcat
-  - id: c8acd2ab7371e39aeca7c306f3b5380f00afe55
+  - id: c8acd2ab7371e39aeca7c306f3b5380f00afe552
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M7

--- a/statements/CVE-2020-13920/statement.yaml
+++ b/statements/CVE-2020-13920/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: activemq-5.15.x
   commits:
-  - id: 48cd61dda07c1ef212d0e9dce5a4398983faf79
+  - id: 48cd61dda07c1ef212d0e9dce5a4398983faf79d
     repository: https://github.com/apache/activemq
 - id: DEFAULT_BRANCH
   commits:
-  - id: 58382283330f7c7b110c7afd8ef4ca264878653
+  - id: 58382283330f7c7b110c7afd8ef4ca2648786532
     repository: https://github.com/apache/activemq
 artifacts:
 - id: pkg:maven/org.apache.activemq/activemq-broker@5.15.9

--- a/statements/CVE-2020-13933/statement.yaml
+++ b/statements/CVE-2020-13933/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: fdddd7cb982d9be69ea6b74bbe183fa47a22e5e
+  - id: fdddd7cb982d9be69ea6b74bbe183fa47a22e5ee
     repository: https://github.com/apache/shiro
-  - id: 83d8dacd273c8f6d70e6b1aa4f240d4f7a408c2
+  - id: 83d8dacd273c8f6d70e6b1aa4f240d4f7a408c27
     repository: https://github.com/apache/shiro
 artifacts:
 - id: pkg:maven/org.apache.shiro/shiro-web@1.4.0

--- a/statements/CVE-2020-13934/statement.yaml
+++ b/statements/CVE-2020-13934/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: c9167ae30f3b03b112f3d81772e3450b7d0e6a2
+  - id: c9167ae30f3b03b112f3d81772e3450b7d0e6a25
     repository: https://github.com/apache/tomcat
-  - id: 172977f04a5215128f1e278a688983dcd230f39
+  - id: 172977f04a5215128f1e278a688983dcd230f399
     repository: https://github.com/apache/tomcat
-  - id: 923d834500802a61779318911d7898bd85fc950
+  - id: 923d834500802a61779318911d7898bd85fc950e
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M6

--- a/statements/CVE-2020-13935/statement.yaml
+++ b/statements/CVE-2020-13935/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 12d715676038efbf9c728af10163f8277fc019d
+  - id: 12d715676038efbf9c728af10163f8277fc019d5
     repository: https://github.com/apache/tomcat
-  - id: 1c1c77b0efb667cea80b532440b44cea1dc427c
+  - id: 1c1c77b0efb667cea80b532440b44cea1dc427c3
     repository: https://github.com/apache/tomcat
-  - id: 40fa74c74822711ab878079d0a69f7357926723
+  - id: 40fa74c74822711ab878079d0a69f7357926723d
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@8.5.11

--- a/statements/CVE-2020-13941/statement.yaml
+++ b/statements/CVE-2020-13941/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 49a3f0a11d41f7124b893a08dc9e67594c32e2e
+  - id: 49a3f0a11d41f7124b893a08dc9e67594c32e2ee
     repository: https://github.com/apache/lucene-solr
-  - id: b52bf267c7aa528b282d09c637344650f903495
+  - id: b52bf267c7aa528b282d09c637344650f9034956
     repository: https://github.com/apache/lucene-solr
 artifacts:
 - id: pkg:maven/org.apache.solr/solr-core@7.1.0

--- a/statements/CVE-2020-1935/statement.yaml
+++ b/statements/CVE-2020-1935/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 8fbe2e
+  - id: 8fbe2e962f0ea138d92361921643fe5abe0c4f56
     repository: https://github.com/apache/tomcat
-  - id: 702bf1
+  - id: 702bf15bea292915684d931526d95d4990b2e73d
     repository: https://github.com/apache/tomcat
-  - id: 8bfb0f
+  - id: 8bfb0ff7f25fe7555a5eb2f7984f73546c11aa26
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.0.0-M7

--- a/statements/CVE-2020-1937/statement.yaml
+++ b/statements/CVE-2020-1937/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: 2.6.x
   commits:
-  - id: 1f9f44ceb818b46518176e81c6dea5a0d12750c
+  - id: 1f9f44ceb818b46518176e81c6dea5a0d12750cf
     repository: https://github.com/apache/kylin
 - id: 3.0.x
   commits:
-  - id: e373c64c96a54a7abfe4bccb82e8feb60db0474
+  - id: e373c64c96a54a7abfe4bccb82e8feb60db04749
     repository: https://github.com/apache/kylin

--- a/statements/CVE-2020-1938/statement.yaml
+++ b/statements/CVE-2020-1938/statement.yaml
@@ -4,27 +4,27 @@ notes:
 fixes:
 - id: 7.0.x
   commits:
-  - id: 0d633e
+  - id: 0d633e72ebc7b3c242d0081c23bba5e4dacd9b72
     repository: https://github.com/apache/tomcat
-  - id: 40d5d9
+  - id: 40d5d93bd284033cf4a1f77f5492444f83d803e2
     repository: https://github.com/apache/tomcat
 - id: 8.5.x
   commits:
-  - id: b96283
+  - id: b962835f98b905286b78c414d5aaec2d0e711f75
     repository: https://github.com/apache/tomcat
-  - id: 69c560
+  - id: 69c56080fb3355507e1b55d014ec0ee6767a6150
     repository: https://github.com/apache/tomcat
-  - id: 64159a
+  - id: 64159aa1d7cdc2c118fcb5eac098e70129d54a19
     repository: https://github.com/apache/tomcat
-  - id: 03c436
+  - id: 03c436126db6794db5277a3b3d871016fb9a3f23
     repository: https://github.com/apache/tomcat
 - id: 9.0.x
   commits:
-  - id: 64fa5b
+  - id: 64fa5b99442589ef0bf2a7fcd71ad2bc68b35fad
     repository: https://github.com/apache/tomcat
-  - id: 7a1406
+  - id: 7a1406a3cd20fdd90656add6cd8f27ef8f24e957
     repository: https://github.com/apache/tomcat
-  - id: 0e8a50
+  - id: 0e8a50f0a5958744bea1fd6768c862e04d3b7e75
     repository: https://github.com/apache/tomcat
 artifacts:
 - id: pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.0.41

--- a/statements/CVE-2020-1950/statement.yaml
+++ b/statements/CVE-2020-1950/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: branch_1x
   commits:
-  - id: 750d7790c7d8ba766f2794fac79521d5870eadf
+  - id: 750d7790c7d8ba766f2794fac79521d5870eadfb
     repository: https://github.com/apache/tika
 - id: DEFAULT_BRANCH
   commits:
-  - id: ab8a9ed830ec710a32e4ffdf4989aea3aaea92e
+  - id: ab8a9ed830ec710a32e4ffdf4989aea3aaea92ef
     repository: https://github.com/apache/tika
 artifacts:
 - id: pkg:maven/org.apache.tika/tika-parsers@1.19

--- a/statements/CVE-2020-1954/statement.yaml
+++ b/statements/CVE-2020-1954/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 3.3.x-fixes
   commits:
-  - id: 98ec361acd390483005de12ca3b10cf49cbdcf8
+  - id: 98ec361acd390483005de12ca3b10cf49cbdcf8a
     repository: https://github.com/apache/cxf
 - id: DEFAULT_BRANCH
   commits:
-  - id: 1cf4fed546904a4a2560f53a2a2391d834b4026
+  - id: 1cf4fed546904a4a2560f53a2a2391d834b4026c
     repository: https://github.com/apache/cxf
 - id: 3.2.x-fixes
   commits:
-  - id: 8636c3760a97979f42e45080230a27b81df5d43
+  - id: 8636c3760a97979f42e45080230a27b81df5d436
     repository: https://github.com/apache/cxf
 artifacts:
 - id: pkg:maven/org.apache.cxf/cxf-rt-management@2.7.18

--- a/statements/CVE-2020-1960/statement.yaml
+++ b/statements/CVE-2020-1960/statement.yaml
@@ -4,45 +4,45 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 48ca13793825a8095578ddc5724da4178cd18c5
+  - id: 48ca13793825a8095578ddc5724da4178cd18c5c
     repository: https://github.com/apache/flink
 - id: release-1.7
   commits:
-  - id: 5e0b7970a9aea74aba4ebffaa75c37e960799b9
+  - id: 5e0b7970a9aea74aba4ebffaa75c37e960799b93
     repository: https://github.com/apache/flink
 - id: release-1.10
   commits:
-  - id: 804ae70024bf8be7c0c7093d02addb080c31866
+  - id: 804ae70024bf8be7c0c7093d02addb080c318662
     repository: https://github.com/apache/flink
 - id: release-1.1
   commits:
-  - id: a61b5d2b362d11e7b9deeb2334d275325574bd7
+  - id: a61b5d2b362d11e7b9deeb2334d275325574bd7b
     repository: https://github.com/apache/flink
 - id: release-1.8
   commits:
-  - id: 0e8e8062bcc159e9ed2a0d4a0a61db4efcb01f2
+  - id: 0e8e8062bcc159e9ed2a0d4a0a61db4efcb01f2f
     repository: https://github.com/apache/flink
 - id: release-1.4
   commits:
-  - id: 12787eceb49c566b28aa876fc2892d21a0ec3d7
+  - id: 12787eceb49c566b28aa876fc2892d21a0ec3d79
     repository: https://github.com/apache/flink
 - id: release-1.3
   commits:
-  - id: 4f06bb75cd726096af43587ca4fb182b2e4bae2
+  - id: 4f06bb75cd726096af43587ca4fb182b2e4bae2e
     repository: https://github.com/apache/flink
 - id: release-1.9
   commits:
-  - id: 58b58f4b16a2e25c95b465377d43a51ad8ef3f6
+  - id: 58b58f4b16a2e25c95b465377d43a51ad8ef3f6a
     repository: https://github.com/apache/flink
 - id: release-1.6
   commits:
-  - id: b8647b1ca019003ae939b7494bba4e54de167b6
+  - id: b8647b1ca019003ae939b7494bba4e54de167b6f
     repository: https://github.com/apache/flink
 - id: release-1.2
   commits:
-  - id: d2a051267ffbeef5c1fd981860fb7032d9ac8a6
+  - id: d2a051267ffbeef5c1fd981860fb7032d9ac8a60
     repository: https://github.com/apache/flink
 - id: release-1.5
   commits:
-  - id: f9b4e0dea71abbcd6463c757577c70c45b3e6bb
+  - id: f9b4e0dea71abbcd6463c757577c70c45b3e6bbf
     repository: https://github.com/apache/flink

--- a/statements/CVE-2020-5408/statement.yaml
+++ b/statements/CVE-2020-5408/statement.yaml
@@ -4,23 +4,23 @@ notes:
 fixes:
 - id: 5.1.x
   commits:
-  - id: c2296b0376d749aec43a1d68667d39116ccf3bf
+  - id: c2296b0376d749aec43a1d68667d39116ccf3bf2
     repository: https://github.com/spring-projects/spring-security
 - id: 5.3.2
   commits:
-  - id: d1909ec9c8844cfa6b63bab5c2591f14d714ef6
+  - id: d1909ec9c8844cfa6b63bab5c2591f14d714ef6b
     repository: https://github.com/spring-projects/spring-security
 - id: 5.2.4
   commits:
-  - id: 564d5644c993f622db8bc22737471c57dd08d16
+  - id: 564d5644c993f622db8bc22737471c57dd08d166
     repository: https://github.com/spring-projects/spring-security
 - id: 4.2.x
   commits:
-  - id: 3c81e122bdfcd0803fb6331a8625624cae24923
+  - id: 3c81e122bdfcd0803fb6331a8625624cae249231
     repository: https://github.com/spring-projects/spring-security
 - id: 5.0.x
   commits:
-  - id: 62bc17ea3f2d5f052a7e9ce8e909255668034c0
+  - id: 62bc17ea3f2d5f052a7e9ce8e909255668034c07
     repository: https://github.com/spring-projects/spring-security
 artifacts:
 - id: pkg:maven/org.springframework.security/spring-security-core@5.0.13.RELEASE

--- a/statements/CVE-2020-5410/statement.yaml
+++ b/statements/CVE-2020-5410/statement.yaml
@@ -4,15 +4,15 @@ notes:
 fixes:
 - id: 2.1.x
   commits:
-  - id: 03eaadc25323d8c8c89f528e8585033ed90c50f
+  - id: 03eaadc25323d8c8c89f528e8585033ed90c50f6
     repository: https://github.com/spring-cloud/spring-cloud-config
 - id: 3.0.0
   commits:
-  - id: 2ec1acbed9505ab58d275ecd48e5f610d4b25da
+  - id: 2ec1acbed9505ab58d275ecd48e5f610d4b25da4
     repository: https://github.com/spring-cloud/spring-cloud-config
 - id: 2.2.3
   commits:
-  - id: f470b52f1bb52bedac984c2101bea9a3ac52e2e
+  - id: f470b52f1bb52bedac984c2101bea9a3ac52e2e7
     repository: https://github.com/spring-cloud/spring-cloud-config
 artifacts:
 - id: pkg:maven/org.springframework.cloud/spring-cloud-config-server@2.1.9.RELEASE

--- a/statements/CVE-2020-5412/statement.yaml
+++ b/statements/CVE-2020-5412/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 624bbc8b50f7b5b6a1addc62040e4f2587f24f1
+  - id: 624bbc8b50f7b5b6a1addc62040e4f2587f24f1b
     repository: https://github.com/spring-cloud/spring-cloud-netflix
 - id: 2.1.x
   commits:
-  - id: a9f0315aad10fed83d98e5d143a82a5bf859c54
+  - id: a9f0315aad10fed83d98e5d143a82a5bf859c54f
     repository: https://github.com/spring-cloud/spring-cloud-netflix
 artifacts:
 - id: pkg:maven/org.springframework.cloud/spring-cloud-netflix-hystrix-dashboard@1.3.5.RELEASE

--- a/statements/CVE-2020-7009/statement.yaml
+++ b/statements/CVE-2020-7009/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: 6.8
   commits:
-  - id: 1c5f53076b625c44111c1e9430dc36327a08858
+  - id: 1c5f53076b625c44111c1e9430dc36327a088583
     repository: https://github.com/elastic/elasticsearch
 - id: 7.6
   commits:
-  - id: 6f59ef267b2c3567754f8bea87daafc34cd9bd5
+  - id: 6f59ef267b2c3567754f8bea87daafc34cd9bd59
     repository: https://github.com/elastic/elasticsearch
 - id: 7.10
   commits:
-  - id: 7f21ade92407c5c65d2bd83a42e752838acdde5
+  - id: 7f21ade92407c5c65d2bd83a42e752838acdde5b
     repository: https://github.com/elastic/elasticsearch

--- a/statements/CVE-2020-7019/statement.yaml
+++ b/statements/CVE-2020-7019/statement.yaml
@@ -4,13 +4,13 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 011773c8c2a662a011de659806bcf34596ba995
+  - id: 011773c8c2a662a011de659806bcf34596ba995e
     repository: https://github.com/elastic/elasticsearch
 - id: 7.9
   commits:
-  - id: 37a38081ec1bf375ce6d480f147a1fdf04e9538
+  - id: 37a38081ec1bf375ce6d480f147a1fdf04e9538b
     repository: https://github.com/elastic/elasticsearch
 - id: 6.8
   commits:
-  - id: 8dbcd49dc71f0bb9b78b19a4cfb84af599b9c32
+  - id: 8dbcd49dc71f0bb9b78b19a4cfb84af599b9c32e
     repository: https://github.com/elastic/elasticsearch

--- a/statements/CVE-2020-9480/statement.yaml
+++ b/statements/CVE-2020-9480/statement.yaml
@@ -4,9 +4,9 @@ notes:
 fixes:
 - id: DEFAULT_BRANCH
   commits:
-  - id: 9416b7c54bdf5613c1a65e6d1779a87591c6c9b
+  - id: 9416b7c54bdf5613c1a65e6d1779a87591c6c9bd
     repository: https://github.com/apache/spark
-  - id: c80d5f7aa0fd9e7b37e1bf4175204750098a44a
+  - id: c80d5f7aa0fd9e7b37e1bf4175204750098a44a6
     repository: https://github.com/apache/spark
 artifacts:
 - id: pkg:maven/org.apache.spark/spark-network-common_2.11@2.4.5

--- a/statements/CVE-2020-9488/statement.yaml
+++ b/statements/CVE-2020-9488/statement.yaml
@@ -4,11 +4,11 @@ notes:
 fixes:
 - id: 2.x
   commits:
-  - id: 6851b5
+  - id: 6851b5083ef9610bae320bf07e1f24d2aa08851b
     repository: https://github.com/apache/logging-log4j2
 - id: DEFAULT_BRANCH
   commits:
-  - id: fb91a3
+  - id: fb91a3d71e2f3dadad6fd1beb2ab857f44fe8bbb
     repository: https://github.com/apache/logging-log4j2
 artifacts:
 - id: pkg:maven/org.apache.logging.log4j/log4j-core@2.7


### PR DESCRIPTION
One truncated id (da3a703213e47d87682f6970ca2db8d05a4ada2) remains in `statements/CVE-2019-10156/statement.yaml` because I was not able to locate this commit.

Most of them were fixed with this Python script, with some manual fixes:

```python
from pathlib import Path

import requests
import tqdm
import yaml

for path in tqdm.tqdm(list(Path(".").glob("statements/*/statement.yaml"))):
    stmt = yaml.safe_load(path.read_text())
    for fix in stmt.get("fixes", []):
        for commit in fix.get("commits", []):
            if len(commit["id"]) < 40:
                if commit["repository"].startswith("https://github.com/"):
                    slug = commit["repository"].removeprefix("https://github.com/").removesuffix(".git")
                elif commit["repository"].startswith("https://git-wip-us.apache.org/"):
                    # github redirect
                    slug = commit["repository"].removeprefix("https://git-wip-us.apache.org/repos/").removesuffix(".git")
                elif commit["repository"].startswith("https://gitbox.apache.org/repos/"):
                    # github redirect
                    slug = commit["repository"].removeprefix("https://gitbox.apache.org/repos/").removesuffix(".git")
                elif commit["repository"].startswith(("http://svn.apache.org/", "https://svn.apache.org/")):
                    # subversion, not git
                    continue
                else:
                    assert False, f"Unknown repo: {commit}"
                j = requests.get(f"https://api.github.com/repos/{slug}/commits/{commit['id']}", headers={"Authorization": "Bearer github_pat_[redacted]"}).json()
                if "status" in j:
                    print(path, j)
                    continue
                path.write_text(path.read_text().replace(commit["id"], j["sha"]))
```